### PR TITLE
Develop slack channel organizer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Slack Bot Configuration
+SLACK_BOT_TOKEN=xoxb-your-bot-token-here
+SLACK_SIGNING_SECRET=your-signing-secret-here
+SLACK_APP_TOKEN=xapp-your-app-token-here
+
+# Server Configuration
+PORT=3000
+NODE_ENV=development
+
+# API Configuration
+API_SECRET_KEY=your-api-secret-key-here
+
+# MCP Configuration
+MCP_PORT=3001

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,128 @@
+# Dependencies
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Environment variables
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Logs
+logs/
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Coverage directory used by tools like istanbul
+coverage/
+*.lcov
+
+# nyc test coverage
+.nyc_output
+
+# Grunt intermediate storage
+.grunt
+
+# Bower dependency directory
+bower_components
+
+# node-waf configuration
+.lock-wscript
+
+# Compiled binary addons
+build/Release
+
+# Dependency directories
+node_modules/
+jspm_packages/
+
+# TypeScript v1 declaration files
+typings/
+
+# TypeScript cache
+*.tsbuildinfo
+
+# Optional npm cache directory
+.npm
+
+# Optional eslint cache
+.eslintcache
+
+# Microbundle cache
+.rpt2_cache/
+.rts2_cache_cjs/
+.rts2_cache_es/
+.rts2_cache_umd/
+
+# Optional REPL history
+.node_repl_history
+
+# Output of 'npm pack'
+*.tgz
+
+# Yarn Integrity file
+.yarn-integrity
+
+# parcel-bundler cache
+.cache
+.parcel-cache
+
+# Next.js build output
+.next
+
+# Nuxt.js build / generate output
+.nuxt
+dist
+
+# Gatsby files
+.cache/
+public
+
+# Vuepress build output
+.vuepress/dist
+
+# Serverless directories
+.serverless/
+
+# FuseBox cache
+.fusebox/
+
+# DynamoDB Local files
+.dynamodb/
+
+# TernJS port file
+.tern-port
+
+# MacOS
+.DS_Store
+
+# Windows
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+
+# Linux
+*~
+
+# IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Temporary files
+tmp/
+temp/

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,0 +1,189 @@
+# Slack Channel Grouper Bot - Features Overview
+
+## 🎯 What This Bot Does
+
+Imagine if one could group channels in Slack with regex patterns - **now you can!** This bot allows you to find, organize, and manage Slack channels using powerful regular expression patterns.
+
+## 🚀 Three Ways to Use It
+
+### 1. 💬 Slack Slash Commands
+**Primary Interface:** `/group-channels`
+
+- **Search channels instantly**: `/group-channels search ^dev` 
+- **Save patterns for reuse**: `/group-channels save "engineering" ^(dev|eng|api)`
+- **Apply saved patterns**: `/group-channels apply "engineering"`
+- **Get smart suggestions**: `/group-channels suggestions`
+- **Interactive buttons**: Click to apply patterns directly
+
+### 2. 🌐 REST API
+**Programmatic Access:** Full HTTP API with authentication
+
+- **Endpoint**: `http://localhost:3000/api/*`
+- **Authentication**: API key via header or query parameter
+- **Complete CRUD**: Create, read, update, delete channel groups
+- **JSON responses**: Structured data for integration
+
+### 3. 🤖 MCP (Model Context Protocol)
+**AI Integration:** Connect with AI models and assistants
+
+- **7 MCP tools** for channel operations
+- **Stdio transport** for seamless integration
+- **Structured responses** for AI consumption
+- **Compatible** with Claude, GPT, and other MCP clients
+
+## 🔍 Smart Pattern Matching
+
+### What Gets Searched
+- **Channel names** (e.g., `dev-team`, `project-alpha`)
+- **Channel topics** (e.g., "Development discussions")
+- **Channel purposes** (e.g., "API design collaboration")
+
+### Built-in Pattern Suggestions
+- **Engineering**: `^(dev|eng|engineering|tech|api|backend|frontend)`
+- **Teams**: `team-|^(sales|marketing|hr|design|product)`
+- **Projects**: `project-|proj-`
+- **Temporary**: `(temp|tmp|test|sandbox)`
+- **Date-based**: `\\d{4}|202[0-9]|q[1-4]`
+
+### Real-World Examples
+```bash
+# Find all development channels
+/group-channels search ^dev
+
+# Find team-specific channels
+/group-channels search team-
+
+# Find project channels from 2024
+/group-channels search (project.*2024|2024.*project)
+
+# Find archived test channels
+/group-channels search test.*archive
+```
+
+## 💾 Persistent Storage
+
+### Save Your Patterns
+- **Named groups**: Save patterns with memorable names
+- **User-specific**: Each user has their own saved groups
+- **Quick access**: Apply saved patterns with one command
+- **Management**: List, apply, and delete saved groups
+
+### Example Workflow
+```bash
+# Save a complex pattern
+/group-channels save "all-engineering" ^(dev|eng|api|backend|frontend|infrastructure)
+
+# Use it later
+/group-channels apply "all-engineering"
+
+# Share the pattern (via API)
+curl -X POST /api/groups/U123/engineering \
+  -H "X-API-Key: key" \
+  -d '{"groupName": "engineering", "pattern": "^(dev|eng|api)"}'
+```
+
+## 🎨 Rich User Experience
+
+### Slack Interface Features
+- **Formatted output**: Channels grouped by public/private
+- **Clickable links**: Direct access to public channels
+- **Interactive buttons**: Apply patterns without typing
+- **Pagination**: Shows first 20 results with "show more" indicator
+- **Error handling**: Clear messages for invalid patterns
+
+### API Features
+- **Comprehensive docs**: Built-in documentation at `/api/docs`
+- **Health checks**: Monitor service status
+- **Structured responses**: Consistent JSON format
+- **Error handling**: Meaningful HTTP status codes
+
+### MCP Features
+- **Tool descriptions**: Clear documentation for each tool
+- **Type validation**: Schema-based parameter validation
+- **Error propagation**: Proper error handling for AI models
+
+## 🔧 Technical Capabilities
+
+### Advanced Regex Support
+- **Full JavaScript regex**: All regex features supported
+- **Custom flags**: Case-sensitive, global, multiline options
+- **Pattern validation**: Catches invalid regex before execution
+- **Performance optimized**: Efficient channel scanning
+
+### Channel Information
+- **Complete metadata**: ID, name, privacy, archive status
+- **Topic and purpose**: Search within channel descriptions
+- **Type distinction**: Public vs private channel handling
+- **Archive awareness**: Identify archived channels
+
+### Scalability
+- **Efficient scanning**: Optimized for large workspaces
+- **Rate limiting**: Respects Slack API limits
+- **Caching ready**: Architecture supports future caching
+- **Memory efficient**: Streaming-style channel processing
+
+## 🛡️ Security & Reliability
+
+### Authentication
+- **Slack OAuth**: Standard Slack app authentication
+- **API keys**: Secure REST API access
+- **Permission-based**: Only accesses channels bot can see
+
+### Error Handling
+- **Graceful failures**: Clear error messages
+- **Validation**: Input validation at all levels
+- **Logging**: Comprehensive logging for debugging
+- **Recovery**: Handles API failures gracefully
+
+### Privacy
+- **User isolation**: Saved groups are user-specific
+- **Permission respect**: Only shows accessible channels
+- **No data persistence**: Channel data not stored permanently
+
+## 📊 Use Cases
+
+### For Developers
+- Find all development channels: `^(dev|eng|api)`
+- Locate project-specific channels: `project-[a-z]+`
+- Identify outdated channels: `(old|deprecated|archive)`
+
+### For Project Managers
+- Track project channels: `project-.*2024`
+- Find team channels: `team-(frontend|backend|qa)`
+- Locate planning channels: `(planning|roadmap|sprint)`
+
+### For Admins
+- Clean up old channels: `(temp|test|old)`
+- Audit channel naming: `^[a-z-]+$`
+- Find unstructured names: `[A-Z]|[0-9]{4}`
+
+### For AI Integration
+- Channel discovery for context
+- Automated channel organization
+- Workspace analytics and insights
+- Dynamic channel routing
+
+## 🎯 Why This Matters
+
+### Before This Bot
+❌ Manual channel browsing  
+❌ Limited search capabilities  
+❌ No pattern-based organization  
+❌ Difficult workspace management  
+
+### With This Bot
+✅ **Instant pattern matching**  
+✅ **Regex-powered search**  
+✅ **Saved pattern library**  
+✅ **Multiple interfaces (Slack/API/MCP)**  
+✅ **Programmatic access**  
+✅ **AI integration ready**  
+
+## 🚀 Getting Started
+
+1. **Install**: `npm run setup`
+2. **Configure**: Edit `.env` with your Slack tokens
+3. **Start**: `npm start`
+4. **Test**: `/group-channels help` in Slack
+
+**Ready to organize your Slack workspace like never before!** 🎉

--- a/README.md
+++ b/README.md
@@ -226,9 +226,33 @@ curl -X POST http://localhost:3000/api/channels/group \
 
 ## Deployment 🚀
 
-### Environment Variables
+### Vercel (Serverless) - Recommended
 
-Make sure to set these in production:
+Deploy to Vercel for automatic scaling and global performance:
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/your-username/slack-channel-grouper)
+
+```bash
+# Quick deployment
+npm i -g vercel
+vercel
+
+# Set environment variables
+vercel env add SLACK_BOT_TOKEN
+vercel env add SLACK_SIGNING_SECRET  
+vercel env add API_SECRET_KEY
+
+# Deploy to production
+vercel --prod
+```
+
+📖 **Full Vercel Guide**: See `VERCEL_DEPLOYMENT.md` for complete instructions.
+
+### Traditional Server Deployment
+
+For traditional server deployment with persistent storage:
+
+#### Environment Variables
 
 ```env
 NODE_ENV=production
@@ -239,7 +263,7 @@ API_SECRET_KEY=secure-random-key
 PORT=3000
 ```
 
-### Docker (Optional)
+#### Docker (Optional)
 
 ```dockerfile
 FROM node:18-alpine

--- a/README.md
+++ b/README.md
@@ -1,1 +1,289 @@
-# slack-regex
+# Slack Channel Grouper Bot 🚀
+
+A powerful Slack bot that allows you to group and organize channels using regex patterns. Available as a **slash command**, **REST API**, and **MCP (Model Context Protocol) server**.
+
+## Features ✨
+
+- **🔍 Smart Channel Grouping**: Use regex patterns to find and group channels by name, topic, or purpose
+- **💾 Saved Groups**: Save your favorite patterns for quick reuse
+- **🎯 Pattern Suggestions**: Get suggested patterns for common use cases
+- **🔧 Multiple Interfaces**: 
+  - Slack slash commands
+  - REST API
+  - MCP server for AI model integration
+- **🎨 Interactive UI**: Rich Slack interface with buttons and formatted output
+- **📊 Detailed Results**: See channel counts, types, and metadata
+
+## Quick Start 🚀
+
+### 1. Installation
+
+```bash
+# Clone the repository
+git clone <repository-url>
+cd slack-channel-grouper-bot
+
+# Install dependencies
+npm install
+
+# Copy environment variables
+cp .env.example .env
+```
+
+### 2. Configuration
+
+Edit `.env` file with your Slack credentials:
+
+```env
+# Slack Bot Configuration
+SLACK_BOT_TOKEN=xoxb-your-bot-token-here
+SLACK_SIGNING_SECRET=your-signing-secret-here
+SLACK_APP_TOKEN=xapp-your-app-token-here
+
+# Server Configuration
+PORT=3000
+NODE_ENV=development
+
+# API Configuration
+API_SECRET_KEY=your-api-secret-key-here
+
+# MCP Configuration
+MCP_PORT=3001
+```
+
+### 3. Slack App Setup
+
+1. Go to [api.slack.com](https://api.slack.com/apps) and create a new app
+2. Enable Socket Mode and generate an App Token
+3. Add the following Bot Token Scopes:
+   - `channels:read` - Read public channel information
+   - `groups:read` - Read private channel information
+   - `commands` - Add slash commands
+   - `chat:write` - Send messages
+4. Create a slash command: `/group-channels`
+5. Install the app to your workspace
+
+### 4. Start the Bot
+
+```bash
+# Start main bot (Slack + API)
+npm start
+
+# Start in development mode
+npm run dev
+
+# Start MCP server only
+npm run mcp
+```
+
+## Usage 📖
+
+### Slack Commands
+
+The bot responds to the `/group-channels` slash command:
+
+```
+/group-channels search ^dev          # Find channels starting with "dev"
+/group-channels search team-         # Find channels containing "team-"
+/group-channels save "dev-channels" ^(dev|eng|api)  # Save a pattern
+/group-channels list                 # View saved groups
+/group-channels apply "dev-channels" # Use a saved pattern
+/group-channels delete "dev-channels" # Delete a saved pattern
+/group-channels suggestions          # Get pattern suggestions
+/group-channels help                 # Show help
+```
+
+### Example Patterns
+
+| Pattern | Description | Matches |
+|---------|-------------|---------|
+| `^dev` | Channels starting with "dev" | dev-team, development, dev-ops |
+| `team-` | Channels containing "team-" | team-frontend, marketing-team |
+| `(temp\|test)` | Temporary or test channels | temp-project, test-api |
+| `\d{4}` | Channels with years | project-2024, q4-2023 |
+| `^(eng\|dev\|api)` | Engineering channels | eng-general, dev-ops, api-team |
+
+### REST API
+
+The bot also provides a REST API for programmatic access:
+
+#### Authentication
+Include your API key in the `X-API-Key` header or as `api_key` query parameter.
+
+#### Endpoints
+
+- `GET /api/health` - Health check
+- `GET /api/channels` - Get all channels
+- `POST /api/channels/group` - Group channels by pattern
+- `GET /api/groups/:userId` - Get user's saved groups
+- `POST /api/groups/:userId` - Save a new group
+- `DELETE /api/groups/:userId/:groupName` - Delete a group
+- `POST /api/groups/:userId/:groupName/apply` - Apply a saved group
+- `GET /api/suggestions` - Get pattern suggestions
+- `GET /api/docs` - API documentation
+
+#### Example API Usage
+
+```bash
+# Group channels starting with "dev"
+curl -X POST http://localhost:3000/api/channels/group \
+  -H "X-API-Key: your-api-key" \
+  -H "Content-Type: application/json" \
+  -d '{"pattern": "^dev", "flags": "i"}'
+
+# Save a group pattern
+curl -X POST http://localhost:3000/api/groups/U123456789 \
+  -H "X-API-Key: your-api-key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "groupName": "engineering",
+    "pattern": "^(dev|eng|api)",
+    "flags": "i"
+  }'
+```
+
+### MCP (Model Context Protocol)
+
+The bot includes an MCP server for AI model integration:
+
+```bash
+# Start MCP server
+npm run mcp
+```
+
+**Available MCP Tools:**
+- `group_channels_by_regex` - Group channels by pattern
+- `get_all_channels` - Get all workspace channels
+- `save_channel_group` - Save a named group
+- `get_user_groups` - Get user's saved groups
+- `apply_saved_group` - Apply a saved group
+- `delete_saved_group` - Delete a saved group
+- `get_pattern_suggestions` - Get pattern suggestions
+
+## Advanced Features 🔧
+
+### Pattern Suggestions
+
+The bot includes built-in suggestions for common patterns:
+
+- **Engineering Channels**: `^(dev|eng|engineering|tech|api|backend|frontend)`
+- **Project Channels**: `project-|proj-`
+- **Team Channels**: `team-|^(sales|marketing|hr|design|product)`
+- **Temporary Channels**: `(temp|tmp|test|sandbox)`
+- **Date-based Channels**: `\\d{4}|202[0-9]|q[1-4]`
+
+### Interactive Features
+
+- **Clickable Buttons**: Apply patterns or saved groups with one click
+- **Rich Formatting**: Channels grouped by type (public/private)
+- **Channel Links**: Direct links to public channels
+- **Pagination**: Shows first 20 results with "show more" indicator
+
+### Error Handling
+
+- **Regex Validation**: Invalid patterns are caught and explained
+- **Permission Handling**: Graceful handling of private channels
+- **Rate Limiting**: Respects Slack API rate limits
+- **Logging**: Comprehensive logging for debugging
+
+## Development 🛠️
+
+### Project Structure
+
+```
+src/
+├── config/
+│   └── logger.js          # Winston logging configuration
+├── services/
+│   └── channelGrouper.js  # Core channel grouping logic
+├── slack/
+│   └── commands.js        # Slack command handlers
+├── api/
+│   └── routes.js          # REST API routes
+├── index.js               # Main server file
+└── mcp-server.js          # MCP server implementation
+```
+
+### Key Components
+
+- **ChannelGrouperService**: Core service for channel operations
+- **SlashCommandHandler**: Processes Slack slash commands
+- **APIRoutes**: Express.js REST API endpoints
+- **MCPChannelGrouperServer**: Model Context Protocol server
+
+### Testing
+
+```bash
+# Test the API
+curl http://localhost:3000/health
+
+# Test pattern matching
+curl -X POST http://localhost:3000/api/channels/group \
+  -H "X-API-Key: your-key" \
+  -H "Content-Type: application/json" \
+  -d '{"pattern": "test"}'
+```
+
+## Deployment 🚀
+
+### Environment Variables
+
+Make sure to set these in production:
+
+```env
+NODE_ENV=production
+SLACK_BOT_TOKEN=xoxb-production-token
+SLACK_SIGNING_SECRET=production-signing-secret
+SLACK_APP_TOKEN=xapp-production-app-token
+API_SECRET_KEY=secure-random-key
+PORT=3000
+```
+
+### Docker (Optional)
+
+```dockerfile
+FROM node:18-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --only=production
+COPY src/ ./src/
+EXPOSE 3000
+CMD ["npm", "start"]
+```
+
+## Troubleshooting 🔧
+
+### Common Issues
+
+1. **"Missing API key"** - Set `API_SECRET_KEY` in `.env`
+2. **"Invalid regex pattern"** - Check your regex syntax
+3. **"Failed to fetch channels"** - Verify bot token permissions
+4. **Socket mode errors** - Ensure app token is set correctly
+
+### Logs
+
+Check logs in the `logs/` directory:
+- `logs/error.log` - Error messages only
+- `logs/combined.log` - All log messages
+
+## Contributing 🤝
+
+1. Fork the repository
+2. Create a feature branch: `git checkout -b feature-name`
+3. Make your changes
+4. Add tests if applicable
+5. Submit a pull request
+
+## License 📄
+
+MIT License - see LICENSE file for details.
+
+## Support 💬
+
+- Create an issue for bug reports
+- Use discussions for questions
+- Check the logs for debugging information
+
+---
+
+**Made with ❤️ for better Slack channel organization!**

--- a/VERCEL_DEPLOYMENT.md
+++ b/VERCEL_DEPLOYMENT.md
@@ -1,0 +1,312 @@
+# Vercel Deployment Guide
+
+This guide will help you deploy the Slack Channel Grouper Bot to Vercel as a serverless application.
+
+## 🚀 Quick Deploy
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/your-username/slack-channel-grouper)
+
+## 📋 Prerequisites
+
+1. **Vercel Account**: Sign up at [vercel.com](https://vercel.com)
+2. **GitHub Account**: Your code should be in a GitHub repository
+3. **Slack App**: Set up a Slack app with the required permissions
+
+## 🔧 Environment Variables
+
+Set these environment variables in your Vercel project:
+
+### Required Variables
+```env
+SLACK_BOT_TOKEN=xoxb-your-bot-token-here
+SLACK_SIGNING_SECRET=your-signing-secret-here
+API_SECRET_KEY=your-secure-api-key-here
+```
+
+### Optional Variables
+```env
+NODE_ENV=production
+```
+
+## 📁 Project Structure for Vercel
+
+```
+├── api/                    # Vercel API routes
+│   ├── index.js           # Main endpoint
+│   ├── health.js          # Health check
+│   ├── channels.js        # Channel operations
+│   ├── suggestions.js     # Pattern suggestions
+│   ├── docs.js           # API documentation
+│   └── slack/
+│       └── commands.js    # Slack slash commands
+├── lib/                   # Shared libraries
+│   └── channelGrouper.js  # Core service (serverless)
+├── vercel.json           # Vercel configuration
+└── package.json          # Dependencies
+```
+
+## 🚀 Deployment Steps
+
+### Method 1: Deploy from GitHub (Recommended)
+
+1. **Push to GitHub**:
+   ```bash
+   git add .
+   git commit -m "Add Vercel deployment"
+   git push origin main
+   ```
+
+2. **Connect to Vercel**:
+   - Go to [vercel.com/dashboard](https://vercel.com/dashboard)
+   - Click "New Project"
+   - Import your GitHub repository
+   - Vercel will automatically detect it as a Node.js project
+
+3. **Configure Environment Variables**:
+   - In the Vercel dashboard, go to your project
+   - Navigate to "Settings" → "Environment Variables"
+   - Add the required variables listed above
+
+4. **Deploy**:
+   - Click "Deploy"
+   - Vercel will build and deploy your application
+
+### Method 2: Deploy with Vercel CLI
+
+1. **Install Vercel CLI**:
+   ```bash
+   npm i -g vercel
+   ```
+
+2. **Login to Vercel**:
+   ```bash
+   vercel login
+   ```
+
+3. **Deploy**:
+   ```bash
+   vercel
+   ```
+
+4. **Set Environment Variables**:
+   ```bash
+   vercel env add SLACK_BOT_TOKEN
+   vercel env add SLACK_SIGNING_SECRET
+   vercel env add API_SECRET_KEY
+   ```
+
+5. **Redeploy with Environment Variables**:
+   ```bash
+   vercel --prod
+   ```
+
+## ⚙️ Slack App Configuration
+
+After deployment, update your Slack app configuration:
+
+### 1. Slash Commands
+- Go to your Slack app settings
+- Navigate to "Slash Commands"
+- Edit the `/group-channels` command
+- Set Request URL to: `https://your-app.vercel.app/slack/commands`
+
+### 2. OAuth & Permissions
+Ensure your bot has these scopes:
+- `channels:read`
+- `groups:read` 
+- `commands`
+- `chat:write`
+
+### 3. Install App
+- Install the app to your workspace
+- Copy the Bot User OAuth Token
+- Set it as `SLACK_BOT_TOKEN` in Vercel
+
+## 🧪 Testing Your Deployment
+
+### 1. Health Check
+```bash
+curl https://your-app.vercel.app/api/health
+```
+
+### 2. API Test
+```bash
+curl -H "X-API-Key: your-key" https://your-app.vercel.app/api/suggestions
+```
+
+### 3. Slack Test
+In Slack, try:
+```
+/group-channels help
+/group-channels search ^general
+```
+
+## 📊 Monitoring and Logs
+
+### Vercel Dashboard
+- View function logs in the Vercel dashboard
+- Monitor function invocations and errors
+- Check performance metrics
+
+### Function Logs
+```bash
+vercel logs your-project-name
+```
+
+## 🔒 Security Considerations
+
+### Environment Variables
+- Store sensitive data in Vercel environment variables
+- Never commit secrets to your repository
+- Use strong API keys
+
+### Slack Security
+- Vercel automatically verifies Slack signatures
+- Request timestamps are validated
+- Only authenticated requests are processed
+
+## ⚡ Performance Optimization
+
+### Cold Starts
+- Vercel functions may have cold start latency
+- Keep functions lightweight
+- Consider using Vercel Edge Functions for better performance
+
+### Caching
+- Vercel automatically caches static assets
+- API responses are not cached by default
+- Consider implementing response caching for channels
+
+## 🚨 Limitations
+
+### Serverless Constraints
+- **No persistent storage**: Saved groups are not available
+- **30-second timeout**: Long operations may timeout
+- **Stateless**: Each request is independent
+- **Cold starts**: First request may be slower
+
+### Workarounds
+- Use external storage (Redis, Database) for saved groups
+- Implement caching for channel data
+- Use Vercel Edge Functions for better performance
+
+## 🔧 Troubleshooting
+
+### Common Issues
+
+1. **Environment Variables Not Working**
+   ```bash
+   # Check if variables are set
+   vercel env ls
+   
+   # Redeploy after adding variables
+   vercel --prod
+   ```
+
+2. **Slack Commands Not Working**
+   - Verify the Request URL in Slack app settings
+   - Check Vercel function logs for errors
+   - Ensure SLACK_SIGNING_SECRET is correct
+
+3. **API Authentication Failing**
+   - Verify API_SECRET_KEY is set in Vercel
+   - Check the X-API-Key header format
+   - Try using query parameter: `?api_key=your-key`
+
+4. **Channel Access Issues**
+   - Verify bot token permissions
+   - Check if bot is added to workspace
+   - Ensure correct scopes are granted
+
+### Debug Commands
+```bash
+# Check deployment status
+vercel ls
+
+# View recent logs
+vercel logs
+
+# Check environment variables
+vercel env ls
+
+# Test specific function
+curl -v https://your-app.vercel.app/api/health
+```
+
+## 📈 Scaling Considerations
+
+### Vercel Limits
+- **Hobby Plan**: 100GB-hrs per month
+- **Pro Plan**: 1000GB-hrs per month
+- **Function Duration**: 30 seconds max (Hobby), 60 seconds (Pro)
+
+### Performance Tips
+- Keep dependencies minimal
+- Use dynamic imports for large libraries
+- Implement response caching
+- Consider Vercel Edge Functions for global performance
+
+## 🔄 Updates and Maintenance
+
+### Automatic Deployments
+- Push to `main` branch triggers automatic deployment
+- Use different branches for staging environments
+
+### Manual Deployments
+```bash
+# Deploy to production
+vercel --prod
+
+# Deploy to preview
+vercel
+```
+
+### Rollbacks
+```bash
+# List deployments
+vercel ls
+
+# Promote a previous deployment
+vercel promote [deployment-url]
+```
+
+## 🌐 Custom Domains
+
+1. **Add Domain in Vercel**:
+   - Go to project settings
+   - Navigate to "Domains"
+   - Add your custom domain
+
+2. **Update Slack Configuration**:
+   - Update Request URLs to use your custom domain
+   - Test all endpoints
+
+3. **SSL Certificate**:
+   - Vercel automatically provides SSL certificates
+   - No additional configuration needed
+
+## 📚 Additional Resources
+
+- [Vercel Documentation](https://vercel.com/docs)
+- [Slack API Documentation](https://api.slack.com/)
+- [Node.js on Vercel](https://vercel.com/docs/concepts/functions/serverless-functions)
+- [Environment Variables](https://vercel.com/docs/concepts/projects/environment-variables)
+
+## 🎉 Success!
+
+Your Slack Channel Grouper Bot is now running serverlessly on Vercel! 
+
+### What You Can Do:
+✅ **Group channels**: `/group-channels search ^dev`  
+✅ **Get suggestions**: `/group-channels suggestions`  
+✅ **Use REST API**: `https://your-app.vercel.app/api/docs`  
+✅ **Monitor performance**: Vercel dashboard  
+✅ **Scale automatically**: Vercel handles scaling  
+
+### Next Steps:
+- Set up monitoring and alerts
+- Configure custom domain (optional)
+- Implement caching for better performance
+- Add external storage for saved groups (optional)
+
+Happy channel grouping! 🚀

--- a/api/channels.js
+++ b/api/channels.js
@@ -1,0 +1,91 @@
+/**
+ * Channels API endpoint for Vercel
+ * Handles GET /api/channels and POST /api/channels/group
+ */
+
+const ChannelGrouperService = require('../lib/channelGrouper');
+
+// API authentication middleware
+function authenticate(req) {
+  const apiKey = req.headers['x-api-key'] || req.query.api_key;
+  const expectedKey = process.env.API_SECRET_KEY;
+  
+  if (!expectedKey) {
+    throw new Error('API key not configured on server');
+  }
+  
+  if (!apiKey || apiKey !== expectedKey) {
+    throw new Error('Invalid or missing API key');
+  }
+}
+
+module.exports = async (req, res) => {
+  // Enable CORS
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, X-API-Key');
+  
+  if (req.method === 'OPTIONS') {
+    res.status(200).end();
+    return;
+  }
+
+  try {
+    // Authenticate request
+    authenticate(req);
+    
+    // Initialize channel grouper
+    const channelGrouper = new ChannelGrouperService(process.env.SLACK_BOT_TOKEN);
+
+    if (req.method === 'GET') {
+      // Get all channels
+      const channels = await channelGrouper.getAllChannels();
+      res.status(200).json({
+        success: true,
+        data: {
+          totalChannels: channels.length,
+          channels
+        }
+      });
+      
+    } else if (req.method === 'POST') {
+      // Group channels by pattern
+      const { pattern, flags = 'i' } = req.body;
+      
+      if (!pattern) {
+        return res.status(400).json({
+          success: false,
+          error: 'Pattern is required'
+        });
+      }
+
+      const result = await channelGrouper.groupChannelsByRegex(pattern, flags);
+      
+      res.status(200).json({
+        success: true,
+        data: result
+      });
+      
+    } else {
+      res.status(405).json({
+        success: false,
+        error: 'Method not allowed'
+      });
+    }
+
+  } catch (error) {
+    console.error('Error in channels API:', error);
+    
+    if (error.message.includes('API key')) {
+      res.status(401).json({
+        success: false,
+        error: error.message
+      });
+    } else {
+      res.status(400).json({
+        success: false,
+        error: error.message
+      });
+    }
+  }
+};

--- a/api/docs.js
+++ b/api/docs.js
@@ -1,0 +1,138 @@
+/**
+ * API Documentation endpoint for Vercel
+ * Handles GET /api/docs
+ */
+
+module.exports = async (req, res) => {
+  // Enable CORS
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  
+  if (req.method === 'OPTIONS') {
+    res.status(200).end();
+    return;
+  }
+
+  if (req.method !== 'GET') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const baseUrl = `https://${req.headers.host}`;
+
+  const docs = {
+    title: 'Slack Channel Grouper API',
+    version: '1.0.0',
+    description: 'Serverless API for grouping Slack channels using regex patterns',
+    deployment: 'Vercel Serverless',
+    baseUrl,
+    authentication: {
+      type: 'API Key',
+      header: 'X-API-Key',
+      query: 'api_key',
+      description: 'Include your API key in the X-API-Key header or as api_key query parameter'
+    },
+    endpoints: {
+      'GET /api/health': {
+        description: 'Health check endpoint',
+        parameters: 'None',
+        response: 'Health status object',
+        example: `${baseUrl}/api/health`
+      },
+      'GET /api/channels': {
+        description: 'Get all channels in the workspace',
+        parameters: 'None',
+        authentication: 'Required',
+        response: 'Array of channel objects',
+        example: `${baseUrl}/api/channels`
+      },
+      'POST /api/channels': {
+        description: 'Group channels by regex pattern',
+        authentication: 'Required',
+        parameters: {
+          pattern: 'string (required) - Regex pattern',
+          flags: 'string (optional) - Regex flags (default: "i")'
+        },
+        response: 'Grouping result with matched channels',
+        example: `${baseUrl}/api/channels`
+      },
+      'GET /api/suggestions': {
+        description: 'Get suggested regex patterns',
+        parameters: 'None',
+        authentication: 'Required',
+        response: 'Array of pattern suggestions',
+        example: `${baseUrl}/api/suggestions`
+      },
+      'POST /slack/commands': {
+        description: 'Slack slash command endpoint',
+        parameters: 'Slack command payload',
+        authentication: 'Slack signature verification',
+        response: 'Slack message response',
+        note: 'Configure this URL in your Slack app slash command settings'
+      }
+    },
+    examples: {
+      'Get all channels': {
+        method: 'GET',
+        url: `${baseUrl}/api/channels`,
+        headers: {
+          'X-API-Key': 'your-api-key-here'
+        }
+      },
+      'Group channels starting with "dev"': {
+        method: 'POST',
+        url: `${baseUrl}/api/channels`,
+        headers: {
+          'Content-Type': 'application/json',
+          'X-API-Key': 'your-api-key-here'
+        },
+        body: {
+          pattern: '^dev',
+          flags: 'i'
+        }
+      },
+      'Get pattern suggestions': {
+        method: 'GET',
+        url: `${baseUrl}/api/suggestions`,
+        headers: {
+          'X-API-Key': 'your-api-key-here'
+        }
+      }
+    },
+    curlExamples: {
+      'Health check': `curl ${baseUrl}/api/health`,
+      'Get channels': `curl -H "X-API-Key: your-key" ${baseUrl}/api/channels`,
+      'Group channels': `curl -X POST -H "Content-Type: application/json" -H "X-API-Key: your-key" -d '{"pattern":"^dev"}' ${baseUrl}/api/channels`,
+      'Get suggestions': `curl -H "X-API-Key: your-key" ${baseUrl}/api/suggestions`
+    },
+    slackSetup: {
+      description: 'To use with Slack, configure these URLs in your Slack app:',
+      slashCommand: {
+        requestUrl: `${baseUrl}/slack/commands`,
+        description: 'Use this URL for the /group-channels slash command'
+      },
+      environmentVariables: [
+        'SLACK_BOT_TOKEN - Your Slack bot token (xoxb-...)',
+        'SLACK_SIGNING_SECRET - Your Slack app signing secret',
+        'API_SECRET_KEY - Secret key for API authentication'
+      ]
+    },
+    limitations: {
+      serverless: 'This is a serverless deployment, so:',
+      notes: [
+        'No persistent storage for saved groups',
+        'Each request is stateless',
+        'Cold start latency may occur',
+        'Function timeout limit of 30 seconds'
+      ]
+    },
+    support: {
+      github: 'https://github.com/your-repo/slack-channel-grouper',
+      documentation: 'README.md in the repository',
+      issues: 'Create an issue on GitHub for bug reports'
+    }
+  };
+
+  res.status(200).json(docs);
+};

--- a/api/health.js
+++ b/api/health.js
@@ -1,0 +1,46 @@
+/**
+ * Health check endpoint for Vercel deployment
+ */
+
+module.exports = async (req, res) => {
+  // Enable CORS
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  
+  if (req.method === 'OPTIONS') {
+    res.status(200).end();
+    return;
+  }
+
+  if (req.method !== 'GET') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  try {
+    const health = {
+      status: 'healthy',
+      timestamp: new Date().toISOString(),
+      version: '1.0.0',
+      deployment: 'Vercel Serverless',
+      environment: process.env.NODE_ENV || 'development',
+      region: process.env.VERCEL_REGION || 'unknown',
+      services: {
+        api: 'running',
+        slack: process.env.SLACK_BOT_TOKEN ? 'configured' : 'not configured'
+      },
+      uptime: process.uptime(),
+      memory: process.memoryUsage()
+    };
+
+    res.status(200).json(health);
+  } catch (error) {
+    console.error('Health check failed:', error);
+    res.status(500).json({
+      status: 'unhealthy',
+      timestamp: new Date().toISOString(),
+      error: error.message
+    });
+  }
+};

--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,53 @@
+/**
+ * Main Vercel API endpoint
+ * Serves as the homepage and documentation
+ */
+
+module.exports = async (req, res) => {
+  // Enable CORS
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-API-Key');
+  
+  if (req.method === 'OPTIONS') {
+    res.status(200).end();
+    return;
+  }
+
+  const baseUrl = `https://${req.headers.host}`;
+  
+  const response = {
+    name: 'Slack Channel Grouper Bot',
+    version: '1.0.0',
+    description: 'A serverless bot that groups Slack channels using regex patterns',
+    deployment: 'Vercel Serverless',
+    endpoints: {
+      health: `${baseUrl}/api/health`,
+      channels: `${baseUrl}/api/channels`,
+      groups: `${baseUrl}/api/groups`,
+      suggestions: `${baseUrl}/api/suggestions`,
+      documentation: `${baseUrl}/api/docs`,
+      slack: {
+        commands: `${baseUrl}/slack/commands`,
+        events: `${baseUrl}/slack/events`,
+        interactive: `${baseUrl}/slack/interactive`
+      }
+    },
+    slack: {
+      command: '/group-channels',
+      description: 'Use this command in Slack to group channels by regex patterns',
+      setup: {
+        requestUrl: `${baseUrl}/slack/commands`,
+        interactiveUrl: `${baseUrl}/slack/interactive`
+      }
+    },
+    authentication: {
+      api: 'Include X-API-Key header or api_key query parameter',
+      slack: 'Configure SLACK_BOT_TOKEN and SLACK_SIGNING_SECRET environment variables'
+    },
+    github: 'https://github.com/your-repo/slack-channel-grouper',
+    documentation: `${baseUrl}/api/docs`
+  };
+
+  res.status(200).json(response);
+};

--- a/api/slack/commands.js
+++ b/api/slack/commands.js
@@ -1,0 +1,200 @@
+/**
+ * Slack slash commands endpoint for Vercel
+ * Handles /group-channels command
+ */
+
+const crypto = require('crypto');
+const qs = require('querystring');
+const ChannelGrouperService = require('../../lib/channelGrouper');
+
+// Verify Slack request signature
+function verifySlackSignature(rawBody, signature, timestamp) {
+  const signingSecret = process.env.SLACK_SIGNING_SECRET;
+  if (!signingSecret) {
+    throw new Error('SLACK_SIGNING_SECRET not configured');
+  }
+
+  const time = Math.floor(new Date().getTime() / 1000);
+  if (Math.abs(time - timestamp) > 300) {
+    throw new Error('Request timestamp too old');
+  }
+
+  const sigBasestring = `v0:${timestamp}:${rawBody}`;
+  const mySignature = `v0=${crypto
+    .createHmac('sha256', signingSecret)
+    .update(sigBasestring, 'utf8')
+    .digest('hex')}`;
+
+  if (signature !== mySignature) {
+    throw new Error('Invalid signature');
+  }
+}
+
+// Parse command arguments
+function parseCommand(text) {
+  const args = text.trim().split(/\s+/);
+  const command = args[0] || 'help';
+  const params = args.slice(1);
+  
+  return { command, params, rawText: text };
+}
+
+// Handle search/group command
+async function handleSearch(channelGrouper, params) {
+  if (params.length === 0) {
+    return {
+      text: '❌ Please provide a regex pattern. Example: `/group-channels search ^dev`',
+      response_type: 'ephemeral'
+    };
+  }
+
+  const pattern = params.join(' ');
+  const result = await channelGrouper.groupChannelsByRegex(pattern);
+  const formatted = channelGrouper.formatChannelsForSlack(result);
+
+  return {
+    ...formatted,
+    response_type: 'in_channel'
+  };
+}
+
+// Handle suggestions command
+async function handleSuggestions(channelGrouper) {
+  const suggestions = channelGrouper.getSuggestions();
+
+  const blocks = [
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: '*🔍 Suggested Channel Grouping Patterns:*'
+      }
+    },
+    {
+      type: 'divider'
+    }
+  ];
+
+  suggestions.forEach(suggestion => {
+    blocks.push({
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `*${suggestion.name}*\n\`${suggestion.pattern}\`\n_${suggestion.description}_`
+      }
+    });
+  });
+
+  return {
+    text: 'Channel grouping suggestions',
+    blocks,
+    response_type: 'ephemeral'
+  };
+}
+
+// Handle help command
+async function handleHelp() {
+  const helpText = `
+*🤖 Channel Grouper Bot Help*
+
+*Available Commands:*
+• \`/group-channels search <regex>\` - Find channels matching a regex pattern
+• \`/group-channels suggestions\` - View common grouping patterns
+• \`/group-channels help\` - Show this help message
+
+*Examples:*
+• \`/group-channels search ^dev\` - Find channels starting with "dev"
+• \`/group-channels search team-\` - Find channels containing "team-"
+• \`/group-channels search (temp|test)\` - Find temporary or test channels
+
+*Regex Tips:*
+• \`^\` - Start of channel name
+• \`$\` - End of channel name
+• \`|\` - OR operator
+• \`()\` - Grouping
+• \`[]\` - Character sets
+
+*Note:* In serverless mode, saved groups are not available. Use the pattern directly each time.
+  `;
+
+  return {
+    text: helpText,
+    response_type: 'ephemeral'
+  };
+}
+
+module.exports = async (req, res) => {
+  // Enable CORS
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, X-Slack-Signature, X-Slack-Request-Timestamp');
+  
+  if (req.method === 'OPTIONS') {
+    res.status(200).end();
+    return;
+  }
+
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  try {
+    // Get raw body for signature verification
+    let rawBody = '';
+    if (typeof req.body === 'string') {
+      rawBody = req.body;
+    } else if (Buffer.isBuffer(req.body)) {
+      rawBody = req.body.toString();
+    } else {
+      rawBody = JSON.stringify(req.body);
+    }
+
+    // Verify Slack signature
+    const signature = req.headers['x-slack-signature'];
+    const timestamp = req.headers['x-slack-request-timestamp'];
+    
+    if (signature && timestamp) {
+      verifySlackSignature(rawBody, signature, timestamp);
+    }
+
+    // Parse form data
+    const body = typeof req.body === 'string' ? qs.parse(req.body) : req.body;
+    
+    const { command: cmd, params } = parseCommand(body.text || '');
+    
+    console.log(`User ${body.user_id} executed command: ${cmd} with params: ${params.join(' ')}`);
+
+    // Initialize channel grouper
+    const channelGrouper = new ChannelGrouperService(process.env.SLACK_BOT_TOKEN);
+
+    let response;
+
+    switch (cmd) {
+      case 'search':
+      case 'group':
+        response = await handleSearch(channelGrouper, params);
+        break;
+      
+      case 'suggestions':
+      case 'suggest':
+        response = await handleSuggestions(channelGrouper);
+        break;
+      
+      case 'help':
+      default:
+        response = await handleHelp();
+        break;
+    }
+
+    res.status(200).json(response);
+
+  } catch (error) {
+    console.error('Error handling slash command:', error);
+    
+    res.status(200).json({
+      text: `❌ Error: ${error.message}`,
+      response_type: 'ephemeral'
+    });
+  }
+};

--- a/api/suggestions.js
+++ b/api/suggestions.js
@@ -1,0 +1,71 @@
+/**
+ * Suggestions API endpoint for Vercel
+ * Handles GET /api/suggestions
+ */
+
+const ChannelGrouperService = require('../lib/channelGrouper');
+
+// API authentication middleware
+function authenticate(req) {
+  const apiKey = req.headers['x-api-key'] || req.query.api_key;
+  const expectedKey = process.env.API_SECRET_KEY;
+  
+  if (!expectedKey) {
+    throw new Error('API key not configured on server');
+  }
+  
+  if (!apiKey || apiKey !== expectedKey) {
+    throw new Error('Invalid or missing API key');
+  }
+}
+
+module.exports = async (req, res) => {
+  // Enable CORS
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, X-API-Key');
+  
+  if (req.method === 'OPTIONS') {
+    res.status(200).end();
+    return;
+  }
+
+  if (req.method !== 'GET') {
+    res.status(405).json({
+      success: false,
+      error: 'Method not allowed'
+    });
+    return;
+  }
+
+  try {
+    // Authenticate request
+    authenticate(req);
+    
+    // Get suggestions (no need for Slack token)
+    const channelGrouper = new ChannelGrouperService('dummy-token');
+    const suggestions = channelGrouper.getSuggestions();
+    
+    res.status(200).json({
+      success: true,
+      data: {
+        suggestions
+      }
+    });
+
+  } catch (error) {
+    console.error('Error in suggestions API:', error);
+    
+    if (error.message.includes('API key')) {
+      res.status(401).json({
+        success: false,
+        error: error.message
+      });
+    } else {
+      res.status(500).json({
+        success: false,
+        error: error.message
+      });
+    }
+  }
+};

--- a/examples/api-demo.js
+++ b/examples/api-demo.js
@@ -1,0 +1,290 @@
+#!/usr/bin/env node
+
+/**
+ * Demo script for the Slack Channel Grouper Bot API
+ * 
+ * This script demonstrates how to use the REST API to:
+ * 1. Get all channels
+ * 2. Group channels by regex patterns
+ * 3. Save and manage channel groups
+ * 4. Get pattern suggestions
+ */
+
+const https = require('https');
+const http = require('http');
+
+class APIDemo {
+  constructor(baseUrl = 'http://localhost:3000', apiKey = 'demo-key') {
+    this.baseUrl = baseUrl;
+    this.apiKey = apiKey;
+    this.userId = 'U123456789'; // Demo user ID
+  }
+
+  async makeRequest(path, method = 'GET', data = null) {
+    const url = new URL(path, this.baseUrl);
+    const isHttps = url.protocol === 'https:';
+    const client = isHttps ? https : http;
+
+    const options = {
+      hostname: url.hostname,
+      port: url.port || (isHttps ? 443 : 80),
+      path: url.pathname + url.search,
+      method,
+      headers: {
+        'X-API-Key': this.apiKey,
+        'Content-Type': 'application/json',
+        'User-Agent': 'Slack Channel Grouper Demo'
+      }
+    };
+
+    if (data) {
+      const jsonData = JSON.stringify(data);
+      options.headers['Content-Length'] = Buffer.byteLength(jsonData);
+    }
+
+    return new Promise((resolve, reject) => {
+      const req = client.request(options, (res) => {
+        let responseData = '';
+        
+        res.on('data', (chunk) => {
+          responseData += chunk;
+        });
+        
+        res.on('end', () => {
+          try {
+            const parsed = JSON.parse(responseData);
+            resolve({
+              status: res.statusCode,
+              data: parsed
+            });
+          } catch (error) {
+            resolve({
+              status: res.statusCode,
+              data: responseData
+            });
+          }
+        });
+      });
+
+      req.on('error', reject);
+
+      if (data) {
+        req.write(JSON.stringify(data));
+      }
+      
+      req.end();
+    });
+  }
+
+  async healthCheck() {
+    console.log('🏥 Checking API health...');
+    const response = await this.makeRequest('/api/health');
+    console.log(`Status: ${response.status}`);
+    console.log('Response:', JSON.stringify(response.data, null, 2));
+    return response.status === 200;
+  }
+
+  async getAllChannels() {
+    console.log('\n📋 Getting all channels...');
+    const response = await this.makeRequest('/api/channels');
+    
+    if (response.status === 200) {
+      const { totalChannels, channels } = response.data.data;
+      console.log(`Found ${totalChannels} channels`);
+      
+      // Show first 5 channels as sample
+      const sample = channels.slice(0, 5);
+      console.log('Sample channels:');
+      sample.forEach(channel => {
+        console.log(`  • ${channel.name} (${channel.is_private ? 'private' : 'public'})`);
+      });
+    } else {
+      console.log('Error:', response.data);
+    }
+    
+    return response;
+  }
+
+  async groupChannelsByPattern(pattern, flags = 'i') {
+    console.log(`\n🔍 Grouping channels with pattern: ${pattern}`);
+    const response = await this.makeRequest('/api/channels/group', 'POST', {
+      pattern,
+      flags
+    });
+    
+    if (response.status === 200) {
+      const result = response.data.data;
+      console.log(`Pattern: ${result.pattern}`);
+      console.log(`Total channels: ${result.totalChannels}`);
+      console.log(`Matched channels: ${result.matchedChannels}`);
+      
+      if (result.matchedChannels > 0) {
+        console.log('Matching channels:');
+        result.channels.slice(0, 10).forEach(channel => {
+          console.log(`  • ${channel.name} (${channel.is_private ? 'private' : 'public'})`);
+        });
+        
+        if (result.channels.length > 10) {
+          console.log(`  ... and ${result.channels.length - 10} more`);
+        }
+      }
+    } else {
+      console.log('Error:', response.data);
+    }
+    
+    return response;
+  }
+
+  async saveGroup(groupName, pattern, flags = 'i') {
+    console.log(`\n💾 Saving group "${groupName}" with pattern: ${pattern}`);
+    const response = await this.makeRequest(`/api/groups/${this.userId}`, 'POST', {
+      groupName,
+      pattern,
+      flags
+    });
+    
+    if (response.status === 200) {
+      console.log(`✅ Group "${groupName}" saved successfully`);
+    } else {
+      console.log('Error:', response.data);
+    }
+    
+    return response;
+  }
+
+  async getUserGroups() {
+    console.log(`\n📂 Getting saved groups for user ${this.userId}...`);
+    const response = await this.makeRequest(`/api/groups/${this.userId}`);
+    
+    if (response.status === 200) {
+      const { groups } = response.data.data;
+      console.log(`Found ${groups.length} saved groups:`);
+      
+      groups.forEach(group => {
+        console.log(`  • ${group.name}: ${group.pattern} (${group.flags})`);
+      });
+    } else {
+      console.log('Error:', response.data);
+    }
+    
+    return response;
+  }
+
+  async applySavedGroup(groupName) {
+    console.log(`\n🎯 Applying saved group "${groupName}"...`);
+    const response = await this.makeRequest(`/api/groups/${this.userId}/${groupName}/apply`, 'POST');
+    
+    if (response.status === 200) {
+      const result = response.data.data;
+      console.log(`Applied pattern: ${result.pattern}`);
+      console.log(`Matched channels: ${result.matchedChannels}`);
+      
+      if (result.matchedChannels > 0) {
+        console.log('Matching channels:');
+        result.channels.slice(0, 5).forEach(channel => {
+          console.log(`  • ${channel.name}`);
+        });
+      }
+    } else {
+      console.log('Error:', response.data);
+    }
+    
+    return response;
+  }
+
+  async getPatternSuggestions() {
+    console.log('\n💡 Getting pattern suggestions...');
+    const response = await this.makeRequest('/api/suggestions');
+    
+    if (response.status === 200) {
+      const { suggestions } = response.data.data;
+      console.log('Available pattern suggestions:');
+      
+      suggestions.forEach(suggestion => {
+        console.log(`  • ${suggestion.name}`);
+        console.log(`    Pattern: ${suggestion.pattern}`);
+        console.log(`    Description: ${suggestion.description}`);
+        console.log('');
+      });
+    } else {
+      console.log('Error:', response.data);
+    }
+    
+    return response;
+  }
+
+  async deleteGroup(groupName) {
+    console.log(`\n🗑️ Deleting group "${groupName}"...`);
+    const response = await this.makeRequest(`/api/groups/${this.userId}/${groupName}`, 'DELETE');
+    
+    if (response.status === 200) {
+      console.log(`✅ Group "${groupName}" deleted successfully`);
+    } else {
+      console.log('Error:', response.data);
+    }
+    
+    return response;
+  }
+
+  async runDemo() {
+    console.log('🚀 Starting Slack Channel Grouper API Demo\n');
+    console.log('This demo will show you how to use the REST API');
+    console.log('Make sure the bot is running on', this.baseUrl);
+    console.log('=' .repeat(60));
+
+    try {
+      // 1. Health check
+      const isHealthy = await this.healthCheck();
+      if (!isHealthy) {
+        console.log('❌ API is not healthy. Make sure the bot is running.');
+        return;
+      }
+
+      // 2. Get all channels
+      await this.getAllChannels();
+
+      // 3. Try some pattern matching
+      await this.groupChannelsByPattern('^dev');
+      await this.groupChannelsByPattern('team-');
+      await this.groupChannelsByPattern('(test|temp)');
+
+      // 4. Save some groups
+      await this.saveGroup('dev-channels', '^(dev|development|engineering)');
+      await this.saveGroup('team-channels', 'team-');
+
+      // 5. List saved groups
+      await this.getUserGroups();
+
+      // 6. Apply a saved group
+      await this.applySavedGroup('dev-channels');
+
+      // 7. Get suggestions
+      await this.getPatternSuggestions();
+
+      // 8. Cleanup - delete demo groups
+      await this.deleteGroup('dev-channels');
+      await this.deleteGroup('team-channels');
+
+      console.log('\n🎉 Demo completed successfully!');
+      console.log('\nNext steps:');
+      console.log('• Set up your Slack bot tokens in .env');
+      console.log('• Create your slash command in Slack');
+      console.log('• Try the patterns in your Slack workspace');
+
+    } catch (error) {
+      console.error('❌ Demo failed:', error.message);
+      console.log('\nTroubleshooting:');
+      console.log('• Make sure the bot is running: npm start');
+      console.log('• Check your API key in the script');
+      console.log('• Verify the base URL is correct');
+    }
+  }
+}
+
+// Run the demo if this file is executed directly
+if (require.main === module) {
+  const demo = new APIDemo();
+  demo.runDemo();
+}
+
+module.exports = APIDemo;

--- a/examples/vercel-test.js
+++ b/examples/vercel-test.js
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+
+/**
+ * Test script for Vercel deployment
+ * Tests all serverless endpoints
+ */
+
+const https = require('https');
+const http = require('http');
+
+class VercelTestSuite {
+  constructor(baseUrl = 'http://localhost:3000', apiKey = 'test-key') {
+    this.baseUrl = baseUrl;
+    this.apiKey = apiKey;
+  }
+
+  async makeRequest(path, method = 'GET', data = null, headers = {}) {
+    const url = new URL(path, this.baseUrl);
+    const isHttps = url.protocol === 'https:';
+    const client = isHttps ? https : http;
+
+    const options = {
+      hostname: url.hostname,
+      port: url.port || (isHttps ? 443 : 80),
+      path: url.pathname + url.search,
+      method,
+      headers: {
+        'Content-Type': 'application/json',
+        'User-Agent': 'Vercel Test Suite',
+        ...headers
+      }
+    };
+
+    if (data) {
+      const jsonData = JSON.stringify(data);
+      options.headers['Content-Length'] = Buffer.byteLength(jsonData);
+    }
+
+    return new Promise((resolve, reject) => {
+      const req = client.request(options, (res) => {
+        let responseData = '';
+        
+        res.on('data', (chunk) => {
+          responseData += chunk;
+        });
+        
+        res.on('end', () => {
+          try {
+            const parsed = JSON.parse(responseData);
+            resolve({
+              status: res.statusCode,
+              headers: res.headers,
+              data: parsed
+            });
+          } catch (error) {
+            resolve({
+              status: res.statusCode,
+              headers: res.headers,
+              data: responseData
+            });
+          }
+        });
+      });
+
+      req.on('error', reject);
+
+      if (data) {
+        req.write(JSON.stringify(data));
+      }
+      
+      req.end();
+    });
+  }
+
+  async testEndpoint(name, path, method = 'GET', data = null, headers = {}, expectedStatus = 200) {
+    console.log(`\n🧪 Testing: ${name}`);
+    console.log(`   ${method} ${path}`);
+    
+    try {
+      const response = await this.makeRequest(path, method, data, headers);
+      
+      if (response.status === expectedStatus) {
+        console.log(`   ✅ Status: ${response.status} (Expected: ${expectedStatus})`);
+        return { success: true, response };
+      } else {
+        console.log(`   ❌ Status: ${response.status} (Expected: ${expectedStatus})`);
+        console.log(`   Response:`, JSON.stringify(response.data, null, 2));
+        return { success: false, response };
+      }
+    } catch (error) {
+      console.log(`   ❌ Error: ${error.message}`);
+      return { success: false, error };
+    }
+  }
+
+  async runTests() {
+    console.log('🚀 Starting Vercel Deployment Test Suite');
+    console.log(`🌐 Base URL: ${this.baseUrl}`);
+    console.log('=' .repeat(60));
+
+    const results = [];
+
+    // Test 1: Health check (no auth required)
+    results.push(await this.testEndpoint(
+      'Health Check',
+      '/api/health'
+    ));
+
+    // Test 2: Main endpoint
+    results.push(await this.testEndpoint(
+      'Main Endpoint',
+      '/'
+    ));
+
+    // Test 3: API documentation
+    results.push(await this.testEndpoint(
+      'API Documentation',
+      '/api/docs'
+    ));
+
+    // Test 4: Suggestions endpoint (with auth)
+    results.push(await this.testEndpoint(
+      'Pattern Suggestions',
+      '/api/suggestions',
+      'GET',
+      null,
+      { 'X-API-Key': this.apiKey }
+    ));
+
+    // Test 5: Suggestions endpoint (without auth - should fail)
+    results.push(await this.testEndpoint(
+      'Suggestions without auth (should fail)',
+      '/api/suggestions',
+      'GET',
+      null,
+      {},
+      401
+    ));
+
+    // Test 6: Channels endpoint (with auth) - might fail without valid Slack token
+    results.push(await this.testEndpoint(
+      'Get Channels (may fail without Slack token)',
+      '/api/channels',
+      'GET',
+      null,
+      { 'X-API-Key': this.apiKey },
+      200 // May return 400 if Slack token is invalid
+    ));
+
+    // Test 7: Group channels endpoint
+    results.push(await this.testEndpoint(
+      'Group Channels (may fail without Slack token)',
+      '/api/channels',
+      'POST',
+      { pattern: '^general', flags: 'i' },
+      { 'X-API-Key': this.apiKey },
+      200 // May return 400 if Slack token is invalid
+    ));
+
+    // Test 8: Slack command endpoint (without proper signature - should fail)
+    results.push(await this.testEndpoint(
+      'Slack Command (should fail without signature)',
+      '/slack/commands',
+      'POST',
+      'command=/group-channels&text=help&user_id=U123456',
+      { 'Content-Type': 'application/x-www-form-urlencoded' },
+      200 // May still return 200 but with error message
+    ));
+
+    // Test 9: Invalid endpoint
+    results.push(await this.testEndpoint(
+      'Invalid Endpoint (should fail)',
+      '/api/nonexistent',
+      'GET',
+      null,
+      {},
+      404
+    ));
+
+    // Test 10: CORS preflight
+    results.push(await this.testEndpoint(
+      'CORS Preflight',
+      '/api/health',
+      'OPTIONS',
+      null,
+      {},
+      200
+    ));
+
+    console.log('\n' + '=' .repeat(60));
+    console.log('📊 TEST RESULTS SUMMARY');
+    console.log('=' .repeat(60));
+
+    const passed = results.filter(r => r.success).length;
+    const total = results.length;
+    
+    console.log(`✅ Passed: ${passed}/${total}`);
+    console.log(`❌ Failed: ${total - passed}/${total}`);
+
+    if (passed === total) {
+      console.log('\n🎉 All tests passed! Your Vercel deployment is working correctly.');
+    } else {
+      console.log('\n⚠️  Some tests failed. This might be expected if:');
+      console.log('   • Slack tokens are not configured');
+      console.log('   • API key is not set correctly');
+      console.log('   • App is not deployed yet');
+    }
+
+    console.log('\n🔧 Next Steps:');
+    console.log('   1. Configure environment variables in Vercel');
+    console.log('   2. Set up your Slack app with proper URLs');
+    console.log('   3. Test the Slack commands in your workspace');
+    console.log('   4. Monitor function logs in Vercel dashboard');
+
+    console.log('\n📖 Documentation:');
+    console.log(`   • API Docs: ${this.baseUrl}/api/docs`);
+    console.log('   • Deployment Guide: VERCEL_DEPLOYMENT.md');
+    console.log('   • Vercel Dashboard: https://vercel.com/dashboard');
+  }
+}
+
+// Command line usage
+if (require.main === module) {
+  const args = process.argv.slice(2);
+  const baseUrl = args[0] || 'http://localhost:3000';
+  const apiKey = args[1] || 'test-key';
+  
+  console.log('Usage: node examples/vercel-test.js [baseUrl] [apiKey]');
+  console.log('Examples:');
+  console.log('  node examples/vercel-test.js');
+  console.log('  node examples/vercel-test.js https://your-app.vercel.app your-api-key');
+  console.log('');
+  
+  const testSuite = new VercelTestSuite(baseUrl, apiKey);
+  testSuite.runTests().catch(console.error);
+}
+
+module.exports = VercelTestSuite;

--- a/lib/channelGrouper.js
+++ b/lib/channelGrouper.js
@@ -1,0 +1,171 @@
+const { WebClient } = require('@slack/web-api');
+
+class ServerlessChannelGrouperService {
+  constructor(token) {
+    this.slack = new WebClient(token);
+  }
+
+  /**
+   * Get all channels in the workspace
+   */
+  async getAllChannels() {
+    try {
+      const result = await this.slack.conversations.list({
+        types: 'public_channel,private_channel',
+        limit: 1000
+      });
+      
+      return result.channels.map(channel => ({
+        id: channel.id,
+        name: channel.name,
+        is_private: channel.is_private,
+        is_archived: channel.is_archived,
+        topic: channel.topic?.value || '',
+        purpose: channel.purpose?.value || ''
+      }));
+    } catch (error) {
+      console.error('Error fetching channels:', error);
+      throw new Error('Failed to fetch channels');
+    }
+  }
+
+  /**
+   * Group channels by regex pattern
+   */
+  async groupChannelsByRegex(pattern, flags = 'i') {
+    try {
+      const regex = new RegExp(pattern, flags);
+      const channels = await this.getAllChannels();
+      
+      const matchedChannels = channels.filter(channel => {
+        return regex.test(channel.name) || 
+               regex.test(channel.topic) || 
+               regex.test(channel.purpose);
+      });
+
+      return {
+        pattern,
+        flags,
+        totalChannels: channels.length,
+        matchedChannels: matchedChannels.length,
+        channels: matchedChannels
+      };
+    } catch (error) {
+      console.error('Error grouping channels:', error);
+      if (error.message.includes('Invalid regular expression')) {
+        throw new Error('Invalid regex pattern provided');
+      }
+      throw new Error('Failed to group channels');
+    }
+  }
+
+  /**
+   * Get group suggestions based on common patterns
+   */
+  getSuggestions() {
+    return [
+      {
+        name: 'Engineering Channels',
+        pattern: '^(dev|eng|engineering|tech|api|backend|frontend)',
+        description: 'Channels starting with development-related keywords'
+      },
+      {
+        name: 'Project Channels',
+        pattern: 'project-|proj-',
+        description: 'Channels containing project prefixes'
+      },
+      {
+        name: 'Team Channels',
+        pattern: 'team-|^(sales|marketing|hr|design|product)',
+        description: 'Team-specific channels'
+      },
+      {
+        name: 'Temporary Channels',
+        pattern: '(temp|tmp|test|sandbox)',
+        description: 'Temporary or testing channels'
+      },
+      {
+        name: 'Date-based Channels',
+        pattern: '\\d{4}|202[0-9]|q[1-4]',
+        description: 'Channels with years or quarters'
+      }
+    ];
+  }
+
+  /**
+   * Format channels for Slack display
+   */
+  formatChannelsForSlack(groupResult, limit = 20) {
+    const { pattern, matchedChannels, channels } = groupResult;
+    
+    if (matchedChannels === 0) {
+      return {
+        text: `No channels found matching pattern: \`${pattern}\``,
+        blocks: []
+      };
+    }
+
+    const displayChannels = channels.slice(0, limit);
+    const hasMore = channels.length > limit;
+
+    const blocks = [
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `*Found ${matchedChannels} channels matching pattern:* \`${pattern}\``
+        }
+      },
+      {
+        type: 'divider'
+      }
+    ];
+
+    // Group channels by type
+    const publicChannels = displayChannels.filter(ch => !ch.is_private);
+    const privateChannels = displayChannels.filter(ch => ch.is_private);
+
+    if (publicChannels.length > 0) {
+      blocks.push({
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `*Public Channels (${publicChannels.length}):*\n${publicChannels.map(ch => 
+            `• <#${ch.id}|${ch.name}>${ch.is_archived ? ' (archived)' : ''}`
+          ).join('\n')}`
+        }
+      });
+    }
+
+    if (privateChannels.length > 0) {
+      blocks.push({
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `*Private Channels (${privateChannels.length}):*\n${privateChannels.map(ch => 
+            `• #${ch.name}${ch.is_archived ? ' (archived)' : ''}`
+          ).join('\n')}`
+        }
+      });
+    }
+
+    if (hasMore) {
+      blocks.push({
+        type: 'context',
+        elements: [
+          {
+            type: 'mrkdwn',
+            text: `_Showing first ${limit} channels. ${channels.length - limit} more channels match this pattern._`
+          }
+        ]
+      });
+    }
+
+    return {
+      text: `Found ${matchedChannels} channels matching pattern: ${pattern}`,
+      blocks
+    };
+  }
+}
+
+module.exports = ServerlessChannelGrouperService;

--- a/mcp-config.json
+++ b/mcp-config.json
@@ -1,0 +1,62 @@
+{
+  "mcpServers": {
+    "slack-channel-grouper": {
+      "command": "node",
+      "args": ["src/mcp-server.js"],
+      "env": {
+        "NODE_ENV": "production"
+      },
+      "description": "Groups Slack channels using regex patterns",
+      "capabilities": {
+        "tools": [
+          {
+            "name": "group_channels_by_regex",
+            "description": "Group Slack channels using a regex pattern",
+            "examples": [
+              "Find all dev channels: pattern='^dev'",
+              "Find team channels: pattern='team-'",
+              "Find temporary channels: pattern='(temp|test)'"
+            ]
+          },
+          {
+            "name": "get_all_channels",
+            "description": "Get all channels in the Slack workspace"
+          },
+          {
+            "name": "save_channel_group",
+            "description": "Save a named channel group with a regex pattern"
+          },
+          {
+            "name": "get_user_groups",
+            "description": "Get all saved groups for a user"
+          },
+          {
+            "name": "apply_saved_group",
+            "description": "Apply a saved group pattern to find matching channels"
+          },
+          {
+            "name": "delete_saved_group",
+            "description": "Delete a saved channel group"
+          },
+          {
+            "name": "get_pattern_suggestions",
+            "description": "Get suggested regex patterns for common channel groupings"
+          }
+        ]
+      },
+      "setup": {
+        "instructions": [
+          "1. Install dependencies: npm install",
+          "2. Copy .env.example to .env and configure your Slack tokens",
+          "3. Start the MCP server: npm run mcp",
+          "4. The server will be available via stdio transport"
+        ],
+        "requirements": [
+          "Node.js 16+",
+          "Valid Slack Bot Token with channels:read and groups:read permissions",
+          "Slack App Token for Socket Mode"
+        ]
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3495 @@
+{
+  "name": "slack-channel-grouper-bot",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "slack-channel-grouper-bot",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^0.4.0",
+        "@slack/bolt": "^3.17.1",
+        "@slack/web-api": "^6.10.0",
+        "cors": "^2.8.5",
+        "dotenv": "^16.3.1",
+        "express": "^4.18.2",
+        "helmet": "^7.1.0",
+        "winston": "^3.11.0"
+      },
+      "devDependencies": {
+        "nodemon": "^3.0.2"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
+      "integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
+      "license": "MIT",
+      "dependencies": {
+        "colorspace": "1.1.x",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-0.4.0.tgz",
+      "integrity": "sha512-79gx8xh4o9YzdbtqMukOe5WKzvEZpvBA1x8PAgJWL7J5k06+vJx8NK2kWzOazPgqnfDego7cNEO8tjai/nOPAA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "raw-body": "^3.0.0",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@slack/bolt": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@slack/bolt/-/bolt-3.22.0.tgz",
+      "integrity": "sha512-iKDqGPEJDnrVwxSVlFW6OKTkijd7s4qLBeSufoBsTM0reTyfdp/5izIQVkxNfzjHi3o6qjdYbRXkYad5HBsBog==",
+      "license": "MIT",
+      "dependencies": {
+        "@slack/logger": "^4.0.0",
+        "@slack/oauth": "^2.6.3",
+        "@slack/socket-mode": "^1.3.6",
+        "@slack/types": "^2.13.0",
+        "@slack/web-api": "^6.13.0",
+        "@types/express": "^4.16.1",
+        "@types/promise.allsettled": "^1.0.3",
+        "@types/tsscmp": "^1.0.0",
+        "axios": "^1.7.4",
+        "express": "^4.21.0",
+        "path-to-regexp": "^8.1.0",
+        "promise.allsettled": "^1.0.2",
+        "raw-body": "^2.3.3",
+        "tsscmp": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=14.21.3",
+        "npm": ">=6.14.18"
+      }
+    },
+    "node_modules/@slack/bolt/node_modules/raw-body": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@slack/logger": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-4.0.0.tgz",
+      "integrity": "sha512-Wz7QYfPAlG/DR+DfABddUZeNgoeY7d1J39OCR2jR+v7VBsB8ezulDK5szTnDDPDwLH5IWhLvXIHlCFZV7MSKgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=18.0.0"
+      },
+      "engines": {
+        "node": ">= 18",
+        "npm": ">= 8.6.0"
+      }
+    },
+    "node_modules/@slack/oauth": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/@slack/oauth/-/oauth-2.6.3.tgz",
+      "integrity": "sha512-1amXs6xRkJpoH6zSgjVPgGEJXCibKNff9WNDijcejIuVy1HFAl1adh7lehaGNiHhTWfQkfKxBiF+BGn56kvoFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@slack/logger": "^3.0.0",
+        "@slack/web-api": "^6.12.1",
+        "@types/jsonwebtoken": "^8.3.7",
+        "@types/node": ">=12",
+        "jsonwebtoken": "^9.0.0",
+        "lodash.isstring": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=12.13.0",
+        "npm": ">=6.12.0"
+      }
+    },
+    "node_modules/@slack/oauth/node_modules/@slack/logger": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-3.0.0.tgz",
+      "integrity": "sha512-DTuBFbqu4gGfajREEMrkq5jBhcnskinhr4+AnfJEk48zhVeEv3XnUKGIX98B74kxhYsIMfApGGySTn7V3b5yBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=12.0.0"
+      },
+      "engines": {
+        "node": ">= 12.13.0",
+        "npm": ">= 6.12.0"
+      }
+    },
+    "node_modules/@slack/socket-mode": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@slack/socket-mode/-/socket-mode-1.3.6.tgz",
+      "integrity": "sha512-G+im7OP7jVqHhiNSdHgv2VVrnN5U7KY845/5EZimZkrD4ZmtV0P3BiWkgeJhPtdLuM7C7i6+M6h6Bh+S4OOalA==",
+      "license": "MIT",
+      "dependencies": {
+        "@slack/logger": "^3.0.0",
+        "@slack/web-api": "^6.12.1",
+        "@types/node": ">=12.0.0",
+        "@types/ws": "^7.4.7",
+        "eventemitter3": "^5",
+        "finity": "^0.5.4",
+        "ws": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=12.13.0",
+        "npm": ">=6.12.0"
+      }
+    },
+    "node_modules/@slack/socket-mode/node_modules/@slack/logger": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-3.0.0.tgz",
+      "integrity": "sha512-DTuBFbqu4gGfajREEMrkq5jBhcnskinhr4+AnfJEk48zhVeEv3XnUKGIX98B74kxhYsIMfApGGySTn7V3b5yBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=12.0.0"
+      },
+      "engines": {
+        "node": ">= 12.13.0",
+        "npm": ">= 6.12.0"
+      }
+    },
+    "node_modules/@slack/types": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/@slack/types/-/types-2.15.0.tgz",
+      "integrity": "sha512-livb1gyG3J8ATLBJ3KjZfjHpTRz9btY1m5cgNuXxWJbhwRB1Gwb8Ly6XLJm2Sy1W6h+vLgqIHg7IwKrF1C1Szg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0",
+        "npm": ">= 6.12.0"
+      }
+    },
+    "node_modules/@slack/web-api": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-6.13.0.tgz",
+      "integrity": "sha512-dv65crIgdh9ZYHrevLU6XFHTQwTyDmNqEqzuIrV+Vqe/vgiG6w37oex5ePDU1RGm2IJ90H8iOvHFvzdEO/vB+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@slack/logger": "^3.0.0",
+        "@slack/types": "^2.11.0",
+        "@types/is-stream": "^1.1.0",
+        "@types/node": ">=12.0.0",
+        "axios": "^1.7.4",
+        "eventemitter3": "^3.1.0",
+        "form-data": "^2.5.0",
+        "is-electron": "2.2.2",
+        "is-stream": "^1.1.0",
+        "p-queue": "^6.6.1",
+        "p-retry": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 12.13.0",
+        "npm": ">= 6.12.0"
+      }
+    },
+    "node_modules/@slack/web-api/node_modules/@slack/logger": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-3.0.0.tgz",
+      "integrity": "sha512-DTuBFbqu4gGfajREEMrkq5jBhcnskinhr4+AnfJEk48zhVeEv3XnUKGIX98B74kxhYsIMfApGGySTn7V3b5yBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=12.0.0"
+      },
+      "engines": {
+        "node": ">= 12.13.0",
+        "npm": ">= 6.12.0"
+      }
+    },
+    "node_modules/@slack/web-api/node_modules/eventemitter3": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.23.tgz",
+      "integrity": "sha512-Crp6WY9aTYP3qPi2wGDo9iUe/rceX01UMhnF1jmwDcKCFM6cx7YhGP/Mpr3y9AASpfHixIG0E6azCcL5OcDHsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.19.6",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
+      "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-jkZatu4QVbR60mpIzjINmtS1ZF4a/FqdTUTBeQDVOQ2PYyidtwFKr0B5G6ERukKwliq+7mIXvxyppwzG5EgRYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.9.tgz",
+      "integrity": "sha512-272FMnFGzAVMGtu9tkr29hRL6bZj4Zs1KZNeHLnKqAvp06tAIcarTMwOh8/8bz4FmKRcMxZhZNeUAQsNLoiPhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.0.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.14.tgz",
+      "integrity": "sha512-4zXMWD91vBLGRtHK3YbIoFMia+1nqEz72coM42C5ETjnNCa/heoj7NT1G67iAfOqMmcfhuCZ4uNpyz8EjlAejw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.8.0"
+      }
+    },
+    "node_modules/@types/promise.allsettled": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/promise.allsettled/-/promise.allsettled-1.0.6.tgz",
+      "integrity": "sha512-wA0UT0HeT2fGHzIFV9kWpYz5mdoyLxKrTgMdZQM++5h6pYAFH73HXcQhefg24nD1yivUFEn5KU+EF4b+CXJ4Wg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "0.17.5",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.5.tgz",
+      "integrity": "sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.8",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.8.tgz",
+      "integrity": "sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/tsscmp": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/tsscmp/-/tsscmp-1.0.2.tgz",
+      "integrity": "sha512-cy7BRSU8GYYgxjcx0Py+8lo5MthuDhlyu076KUcYzVNXL23luYgRHkMG2fIFEc6neckeh/ntP82mw+U4QjZq+g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
+      "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/array.prototype.map": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/array.prototype.map/-/array.prototype.map-1.0.8.tgz",
+      "integrity": "sha512-YocPM7bYYu2hXGxWpb5vwZ8cMeudNHYtYBcUDY4Z1GWa53qcnQMWSl25jeBHNzitjl9HW2AWW4ro/S/nftUaOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.6",
+        "es-array-method-boxes-properly": "^1.0.0",
+        "es-object-atoms": "^1.0.0",
+        "is-string": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
+      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
+      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.13.0",
+        "raw-body": "2.5.2",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/raw-body": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/color": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.3",
+        "color-string": "^1.6.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/colorspace": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
+      "integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
+      "license": "MIT",
+      "dependencies": {
+        "color": "^3.1.3",
+        "text-hex": "1.0.x"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-abstract": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.0.tgz",
+      "integrity": "sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==",
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-array-method-boxes-properly": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
+      "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
+      "license": "MIT"
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-get-iterator": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "is-arguments": "^1.1.1",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
+        "is-string": "^1.0.7",
+        "isarray": "^2.0.5",
+        "stop-iteration-iterator": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.0.5",
+        "is-symbol": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
+    "node_modules/express": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.3",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.7.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.3.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.13.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/path-to-regexp": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
+    },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+      "license": "MIT"
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/finity": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/finity/-/finity-0.5.4.tgz",
+      "integrity": "sha512-3l+5/1tuw616Lgb0QBimxfdd2TqaDGpfCBpfX6EqtFmqUV3FtQnVEX4Aa62DagYEqnsTIjZcTfbq9msDbXYgyA==",
+      "license": "MIT"
+    },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+      "license": "MIT"
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.3.tgz",
+      "integrity": "sha512-XHIrMD0NpDrNM/Ckf7XJiBbLl57KEhT3+i3yY+eWm+cqYZJQTZrKo8Y8AWKnuV5GT4scfuUGt9LzNoIx3dU1nQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "mime-types": "^2.1.35",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "functions-have-names": "^1.2.3",
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-7.2.0.tgz",
+      "integrity": "sha512-ZRiwvN089JfMXokizgqEPXsl2Guk094yExfoDXR0cBYWxtBbaSww/w+vT4WEJsBW2iTUi1GgZ6swmoug3Oy4Xw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ignore-by-default": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-electron": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
+      "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==",
+      "license": "MIT"
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
+      "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.0",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "license": "MIT"
+    },
+    "node_modules/iterate-iterator": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/iterate-iterator/-/iterate-iterator-1.0.2.tgz",
+      "integrity": "sha512-t91HubM4ZDQ70M9wqp+pcNpu8OyJ9UAtXntT/Bcsvp5tZMnz9vRa+IunKXeI8AnfZMTv0jNuVEmGeLSMjVvfPw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/iterate-value": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/iterate-value/-/iterate-value-1.0.2.tgz",
+      "integrity": "sha512-A6fMAio4D2ot2r/TYzr4yUWrmwNdsN5xL7+HUiyACE4DXm+q8HtPcnFTp+NnW3k4N05tZ7FVYFFb2CR13NxyHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-get-iterator": "^1.0.2",
+        "iterate-iterator": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/jwa": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
+    },
+    "node_modules/logform": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.6.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/logform/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/nodemon": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.10.tgz",
+      "integrity": "sha512-WDjw3pJ0/0jMFmyNDp3gvY2YizjLmmOUQo6DEBY+JgdvW/yQ9mEeSw6H5ythl5Ny2ytb7f9C2nIbjSxMNzbJXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.5.2",
+        "debug": "^4",
+        "ignore-by-default": "^1.0.1",
+        "minimatch": "^3.1.2",
+        "pstree.remy": "^1.1.8",
+        "semver": "^7.5.3",
+        "simple-update-notifier": "^2.0.0",
+        "supports-color": "^5.5.0",
+        "touch": "^3.1.0",
+        "undefsafe": "^2.0.5"
+      },
+      "bin": {
+        "nodemon": "bin/nodemon.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nodemon"
+      }
+    },
+    "node_modules/nodemon/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/nodemon/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fn.name": "1.x.x"
+      }
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "license": "MIT",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/promise.allsettled": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/promise.allsettled/-/promise.allsettled-1.0.7.tgz",
+      "integrity": "sha512-hezvKvQQmsFkOdrZfYxUxkyxl8mgFQeT259Ajj9PXdbg9VzBCWrItOev72JyWxkCD5VSSqAeHmlN3tWx4DlmsA==",
+      "license": "MIT",
+      "dependencies": {
+        "array.prototype.map": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
+        "get-intrinsic": "^1.2.1",
+        "iterate-value": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/pstree.remy": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
+      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
+      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.6.3",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
+      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.19.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-update-notifier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-object-atoms": "^1.0.0",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+      "license": "MIT"
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/touch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
+      "integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "nodetouch": "bin/nodetouch.js"
+      }
+    },
+    "node_modules/triple-beam": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.x"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
+      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0",
+        "reflect.getprototypeof": "^1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undefsafe": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
+      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/winston": {
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.17.0.tgz",
+      "integrity": "sha512-DLiFIXYC5fMPxaRg832S6F5mJYvePtmO5G9v9IgUFPhXm9/GkXarH/TUrBAVzhTCzAj9anE/+GjrgXp/54nOgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.2",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.7.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.9.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+      "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
+      "license": "MIT",
+      "dependencies": {
+        "logform": "^2.7.0",
+        "readable-stream": "^3.6.2",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "dev": "nodemon src/index.js",
     "mcp": "node src/mcp-server.js",
     "setup": "node setup.js",
-    "demo": "node examples/api-demo.js"
+    "demo": "node examples/api-demo.js",
+    "vercel-build": "echo 'Build completed'",
+    "vercel-dev": "vercel dev"
   },
   "dependencies": {
     "@slack/bolt": "^3.17.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "setup": "node setup.js",
     "demo": "node examples/api-demo.js",
     "vercel-build": "echo 'Build completed'",
-    "vercel-dev": "vercel dev"
+    "vercel-dev": "vercel dev",
+    "test-vercel": "node examples/vercel-test.js"
   },
   "dependencies": {
     "@slack/bolt": "^3.17.1",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "slack-channel-grouper-bot",
+  "version": "1.0.0",
+  "description": "A Slack bot that groups channels using regex patterns",
+  "main": "src/index.js",
+  "scripts": {
+    "start": "node src/index.js",
+    "dev": "nodemon src/index.js",
+    "mcp": "node src/mcp-server.js",
+    "setup": "node setup.js",
+    "demo": "node examples/api-demo.js"
+  },
+  "dependencies": {
+    "@slack/bolt": "^3.17.1",
+    "@slack/web-api": "^6.10.0",
+    "express": "^4.18.2",
+    "dotenv": "^16.3.1",
+    "cors": "^2.8.5",
+    "helmet": "^7.1.0",
+    "@modelcontextprotocol/sdk": "^0.4.0",
+    "winston": "^3.11.0"
+  },
+  "devDependencies": {
+    "nodemon": "^3.0.2"
+  },
+  "keywords": [
+    "slack",
+    "bot",
+    "channels",
+    "regex",
+    "grouping",
+    "mcp"
+  ],
+  "author": "Slack Channel Grouper Bot",
+  "license": "MIT"
+}

--- a/setup.js
+++ b/setup.js
@@ -1,0 +1,262 @@
+#!/usr/bin/env node
+
+/**
+ * Setup script for Slack Channel Grouper Bot
+ * 
+ * This script helps users set up the bot by:
+ * 1. Checking Node.js version
+ * 2. Installing dependencies
+ * 3. Creating .env file
+ * 4. Providing setup instructions
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+class SetupWizard {
+  constructor() {
+    this.envPath = path.join(process.cwd(), '.env');
+    this.envExamplePath = path.join(process.cwd(), '.env.example');
+  }
+
+  log(message, type = 'info') {
+    const symbols = {
+      info: 'ℹ️',
+      success: '✅',
+      warning: '⚠️',
+      error: '❌',
+      question: '❓'
+    };
+    console.log(`${symbols[type]} ${message}`);
+  }
+
+  checkNodeVersion() {
+    this.log('Checking Node.js version...');
+    const nodeVersion = process.version;
+    const majorVersion = parseInt(nodeVersion.slice(1).split('.')[0]);
+    
+    if (majorVersion < 16) {
+      this.log(`Node.js ${majorVersion} detected. Node.js 16+ is required.`, 'error');
+      return false;
+    }
+    
+    this.log(`Node.js ${nodeVersion} ✓`, 'success');
+    return true;
+  }
+
+  checkDependencies() {
+    this.log('Checking package.json...');
+    
+    if (!fs.existsSync('package.json')) {
+      this.log('package.json not found!', 'error');
+      return false;
+    }
+    
+    this.log('package.json found ✓', 'success');
+    return true;
+  }
+
+  installDependencies() {
+    this.log('Installing dependencies...');
+    
+    try {
+      execSync('npm install', { stdio: 'inherit' });
+      this.log('Dependencies installed ✓', 'success');
+      return true;
+    } catch (error) {
+      this.log('Failed to install dependencies', 'error');
+      console.error(error.message);
+      return false;
+    }
+  }
+
+  createEnvFile() {
+    this.log('Setting up environment variables...');
+    
+    if (fs.existsSync(this.envPath)) {
+      this.log('.env file already exists', 'warning');
+      return true;
+    }
+    
+    if (!fs.existsSync(this.envExamplePath)) {
+      this.log('.env.example not found', 'error');
+      return false;
+    }
+    
+    try {
+      fs.copyFileSync(this.envExamplePath, this.envPath);
+      this.log('.env file created ✓', 'success');
+      return true;
+    } catch (error) {
+      this.log('Failed to create .env file', 'error');
+      return false;
+    }
+  }
+
+  createLogsDirectory() {
+    this.log('Creating logs directory...');
+    
+    const logsDir = path.join(process.cwd(), 'logs');
+    if (!fs.existsSync(logsDir)) {
+      fs.mkdirSync(logsDir, { recursive: true });
+      this.log('Logs directory created ✓', 'success');
+    } else {
+      this.log('Logs directory already exists ✓', 'success');
+    }
+  }
+
+  displaySlackSetupInstructions() {
+    console.log('\n' + '='.repeat(60));
+    console.log('🤖 SLACK APP SETUP INSTRUCTIONS');
+    console.log('='.repeat(60));
+    
+    console.log('\n1. Create a Slack App:');
+    console.log('   • Go to https://api.slack.com/apps');
+    console.log('   • Click "Create New App" → "From scratch"');
+    console.log('   • Name your app "Channel Grouper Bot"');
+    console.log('   • Select your workspace');
+    
+    console.log('\n2. Enable Socket Mode:');
+    console.log('   • Go to "Socket Mode" in the sidebar');
+    console.log('   • Enable Socket Mode');
+    console.log('   • Generate an App-Level Token');
+    console.log('   • Copy the token (starts with xapp-)');
+    
+    console.log('\n3. Set OAuth Scopes:');
+    console.log('   • Go to "OAuth & Permissions"');
+    console.log('   • Add these Bot Token Scopes:');
+    console.log('     - channels:read');
+    console.log('     - groups:read');
+    console.log('     - commands');
+    console.log('     - chat:write');
+    
+    console.log('\n4. Create Slash Command:');
+    console.log('   • Go to "Slash Commands"');
+    console.log('   • Click "Create New Command"');
+    console.log('   • Command: /group-channels');
+    console.log('   • Request URL: https://your-domain.com/slack/events');
+    console.log('   • Description: Group channels with regex patterns');
+    
+    console.log('\n5. Install to Workspace:');
+    console.log('   • Go to "Install App"');
+    console.log('   • Click "Install to Workspace"');
+    console.log('   • Copy the Bot User OAuth Token (starts with xoxb-)');
+    
+    console.log('\n6. Get Signing Secret:');
+    console.log('   • Go to "Basic Information"');
+    console.log('   • Copy the Signing Secret');
+  }
+
+  displayEnvConfiguration() {
+    console.log('\n' + '='.repeat(60));
+    console.log('⚙️  ENVIRONMENT CONFIGURATION');
+    console.log('='.repeat(60));
+    
+    console.log('\nEdit the .env file with your Slack credentials:');
+    console.log('');
+    console.log('SLACK_BOT_TOKEN=xoxb-your-bot-token-here');
+    console.log('SLACK_SIGNING_SECRET=your-signing-secret-here');
+    console.log('SLACK_APP_TOKEN=xapp-your-app-token-here');
+    console.log('');
+    console.log('API_SECRET_KEY=your-secure-api-key-here');
+    console.log('');
+    
+    this.log('Generate a secure API key for the REST API', 'warning');
+    this.log('You can use: openssl rand -hex 32', 'info');
+  }
+
+  displayStartupInstructions() {
+    console.log('\n' + '='.repeat(60));
+    console.log('🚀 STARTUP INSTRUCTIONS');
+    console.log('='.repeat(60));
+    
+    console.log('\nAfter configuring your .env file:');
+    console.log('');
+    console.log('1. Start the main bot (Slack + API):');
+    console.log('   npm start');
+    console.log('');
+    console.log('2. Start in development mode:');
+    console.log('   npm run dev');
+    console.log('');
+    console.log('3. Start only the MCP server:');
+    console.log('   npm run mcp');
+    console.log('');
+    console.log('4. Test the API:');
+    console.log('   node examples/api-demo.js');
+    console.log('');
+    
+    console.log('📖 Documentation:');
+    console.log('   • README.md - Complete documentation');
+    console.log('   • http://localhost:3000/api/docs - API documentation');
+    console.log('   • /group-channels help - Slack command help');
+  }
+
+  displayTestingInstructions() {
+    console.log('\n' + '='.repeat(60));
+    console.log('🧪 TESTING THE BOT');
+    console.log('='.repeat(60));
+    
+    console.log('\n1. Test in Slack:');
+    console.log('   /group-channels help');
+    console.log('   /group-channels search ^general');
+    console.log('   /group-channels suggestions');
+    
+    console.log('\n2. Test the API:');
+    console.log('   curl http://localhost:3000/health');
+    console.log('');
+    console.log('   curl -X POST http://localhost:3000/api/channels/group \\');
+    console.log('     -H "X-API-Key: your-api-key" \\');
+    console.log('     -H "Content-Type: application/json" \\');
+    console.log('     -d \'{"pattern": "^general"}\'');
+    
+    console.log('\n3. Test the MCP server:');
+    console.log('   The MCP server runs via stdio transport');
+    console.log('   Integrate it with your AI model or MCP client');
+  }
+
+  async run() {
+    console.log('🚀 Welcome to Slack Channel Grouper Bot Setup!\n');
+    
+    // Check prerequisites
+    if (!this.checkNodeVersion()) {
+      process.exit(1);
+    }
+    
+    if (!this.checkDependencies()) {
+      process.exit(1);
+    }
+    
+    // Install dependencies
+    if (!this.installDependencies()) {
+      process.exit(1);
+    }
+    
+    // Setup files
+    this.createLogsDirectory();
+    this.createEnvFile();
+    
+    // Display instructions
+    this.displaySlackSetupInstructions();
+    this.displayEnvConfiguration();
+    this.displayStartupInstructions();
+    this.displayTestingInstructions();
+    
+    console.log('\n' + '='.repeat(60));
+    this.log('Setup completed! Follow the instructions above to finish configuration.', 'success');
+    console.log('='.repeat(60));
+    
+    console.log('\n📚 Need help? Check out:');
+    console.log('   • README.md for detailed documentation');
+    console.log('   • GitHub issues for support');
+    console.log('   • Slack API documentation: https://api.slack.com/');
+  }
+}
+
+// Run setup if this file is executed directly
+if (require.main === module) {
+  const setup = new SetupWizard();
+  setup.run().catch(console.error);
+}
+
+module.exports = SetupWizard;

--- a/src/api/routes.js
+++ b/src/api/routes.js
@@ -1,0 +1,383 @@
+const express = require('express');
+const helmet = require('helmet');
+const cors = require('cors');
+const logger = require('../config/logger');
+
+class APIRoutes {
+  constructor(channelGrouper) {
+    this.channelGrouper = channelGrouper;
+    this.router = express.Router();
+    this.setupMiddleware();
+    this.setupRoutes();
+  }
+
+  setupMiddleware() {
+    this.router.use(helmet());
+    this.router.use(cors());
+    this.router.use(express.json());
+    
+    // API key authentication middleware
+    this.router.use((req, res, next) => {
+      const apiKey = req.headers['x-api-key'] || req.query.api_key;
+      const expectedKey = process.env.API_SECRET_KEY;
+      
+      if (!expectedKey) {
+        return res.status(500).json({
+          error: 'API key not configured on server'
+        });
+      }
+      
+      if (!apiKey || apiKey !== expectedKey) {
+        return res.status(401).json({
+          error: 'Invalid or missing API key'
+        });
+      }
+      
+      next();
+    });
+
+    // Request logging
+    this.router.use((req, res, next) => {
+      logger.info(`API Request: ${req.method} ${req.path}`, {
+        ip: req.ip,
+        userAgent: req.get('User-Agent'),
+        body: req.body
+      });
+      next();
+    });
+  }
+
+  setupRoutes() {
+    // Health check
+    this.router.get('/health', this.handleHealth.bind(this));
+    
+    // Channel operations
+    this.router.get('/channels', this.handleGetAllChannels.bind(this));
+    this.router.post('/channels/group', this.handleGroupChannels.bind(this));
+    
+    // Saved groups operations
+    this.router.get('/groups/:userId', this.handleGetUserGroups.bind(this));
+    this.router.post('/groups/:userId', this.handleSaveGroup.bind(this));
+    this.router.delete('/groups/:userId/:groupName', this.handleDeleteGroup.bind(this));
+    this.router.post('/groups/:userId/:groupName/apply', this.handleApplyGroup.bind(this));
+    
+    // Suggestions
+    this.router.get('/suggestions', this.handleGetSuggestions.bind(this));
+    
+    // Documentation
+    this.router.get('/docs', this.handleDocs.bind(this));
+  }
+
+  /**
+   * Health check endpoint
+   */
+  async handleHealth(req, res) {
+    try {
+      res.json({
+        status: 'healthy',
+        timestamp: new Date().toISOString(),
+        version: '1.0.0'
+      });
+    } catch (error) {
+      logger.error('Health check failed:', error);
+      res.status(500).json({
+        status: 'unhealthy',
+        error: error.message
+      });
+    }
+  }
+
+  /**
+   * Get all channels
+   */
+  async handleGetAllChannels(req, res) {
+    try {
+      const channels = await this.channelGrouper.getAllChannels();
+      res.json({
+        success: true,
+        data: {
+          totalChannels: channels.length,
+          channels
+        }
+      });
+    } catch (error) {
+      logger.error('Error fetching channels:', error);
+      res.status(500).json({
+        success: false,
+        error: error.message
+      });
+    }
+  }
+
+  /**
+   * Group channels by regex
+   */
+  async handleGroupChannels(req, res) {
+    try {
+      const { pattern, flags = 'i' } = req.body;
+      
+      if (!pattern) {
+        return res.status(400).json({
+          success: false,
+          error: 'Pattern is required'
+        });
+      }
+
+      const result = await this.channelGrouper.groupChannelsByRegex(pattern, flags);
+      
+      res.json({
+        success: true,
+        data: result
+      });
+    } catch (error) {
+      logger.error('Error grouping channels:', error);
+      res.status(400).json({
+        success: false,
+        error: error.message
+      });
+    }
+  }
+
+  /**
+   * Get user's saved groups
+   */
+  async handleGetUserGroups(req, res) {
+    try {
+      const { userId } = req.params;
+      const groups = this.channelGrouper.getUserGroups(userId);
+      
+      res.json({
+        success: true,
+        data: {
+          userId,
+          groups
+        }
+      });
+    } catch (error) {
+      logger.error('Error fetching user groups:', error);
+      res.status(500).json({
+        success: false,
+        error: error.message
+      });
+    }
+  }
+
+  /**
+   * Save a new group
+   */
+  async handleSaveGroup(req, res) {
+    try {
+      const { userId } = req.params;
+      const { groupName, pattern, flags = 'i' } = req.body;
+      
+      if (!groupName || !pattern) {
+        return res.status(400).json({
+          success: false,
+          error: 'Group name and pattern are required'
+        });
+      }
+
+      // Validate regex pattern
+      try {
+        new RegExp(pattern, flags);
+      } catch (regexError) {
+        return res.status(400).json({
+          success: false,
+          error: `Invalid regex pattern: ${regexError.message}`
+        });
+      }
+
+      this.channelGrouper.saveGroup(userId, groupName, pattern, flags);
+      
+      res.json({
+        success: true,
+        data: {
+          message: `Group "${groupName}" saved successfully`,
+          groupName,
+          pattern,
+          flags
+        }
+      });
+    } catch (error) {
+      logger.error('Error saving group:', error);
+      res.status(500).json({
+        success: false,
+        error: error.message
+      });
+    }
+  }
+
+  /**
+   * Delete a saved group
+   */
+  async handleDeleteGroup(req, res) {
+    try {
+      const { userId, groupName } = req.params;
+      const deleted = this.channelGrouper.deleteGroup(userId, groupName);
+      
+      if (deleted) {
+        res.json({
+          success: true,
+          data: {
+            message: `Group "${groupName}" deleted successfully`
+          }
+        });
+      } else {
+        res.status(404).json({
+          success: false,
+          error: `Group "${groupName}" not found`
+        });
+      }
+    } catch (error) {
+      logger.error('Error deleting group:', error);
+      res.status(500).json({
+        success: false,
+        error: error.message
+      });
+    }
+  }
+
+  /**
+   * Apply a saved group
+   */
+  async handleApplyGroup(req, res) {
+    try {
+      const { userId, groupName } = req.params;
+      const result = await this.channelGrouper.applySavedGroup(userId, groupName);
+      
+      res.json({
+        success: true,
+        data: result
+      });
+    } catch (error) {
+      logger.error('Error applying group:', error);
+      res.status(400).json({
+        success: false,
+        error: error.message
+      });
+    }
+  }
+
+  /**
+   * Get pattern suggestions
+   */
+  async handleGetSuggestions(req, res) {
+    try {
+      const suggestions = this.channelGrouper.getSuggestions();
+      
+      res.json({
+        success: true,
+        data: {
+          suggestions
+        }
+      });
+    } catch (error) {
+      logger.error('Error fetching suggestions:', error);
+      res.status(500).json({
+        success: false,
+        error: error.message
+      });
+    }
+  }
+
+  /**
+   * API documentation
+   */
+  async handleDocs(req, res) {
+    const docs = {
+      title: 'Slack Channel Grouper API',
+      version: '1.0.0',
+      description: 'API for grouping Slack channels using regex patterns',
+      authentication: {
+        type: 'API Key',
+        header: 'X-API-Key',
+        description: 'Include your API key in the X-API-Key header or as api_key query parameter'
+      },
+      endpoints: {
+        'GET /api/health': {
+          description: 'Health check endpoint',
+          parameters: 'None',
+          response: 'Health status object'
+        },
+        'GET /api/channels': {
+          description: 'Get all channels in the workspace',
+          parameters: 'None',
+          response: 'Array of channel objects'
+        },
+        'POST /api/channels/group': {
+          description: 'Group channels by regex pattern',
+          parameters: {
+            pattern: 'string (required) - Regex pattern',
+            flags: 'string (optional) - Regex flags (default: "i")'
+          },
+          response: 'Grouping result with matched channels'
+        },
+        'GET /api/groups/:userId': {
+          description: 'Get saved groups for a user',
+          parameters: {
+            userId: 'string (required) - User ID'
+          },
+          response: 'Array of saved groups'
+        },
+        'POST /api/groups/:userId': {
+          description: 'Save a new group for a user',
+          parameters: {
+            userId: 'string (required) - User ID',
+            groupName: 'string (required) - Name of the group',
+            pattern: 'string (required) - Regex pattern',
+            flags: 'string (optional) - Regex flags'
+          },
+          response: 'Success confirmation'
+        },
+        'DELETE /api/groups/:userId/:groupName': {
+          description: 'Delete a saved group',
+          parameters: {
+            userId: 'string (required) - User ID',
+            groupName: 'string (required) - Name of the group to delete'
+          },
+          response: 'Deletion confirmation'
+        },
+        'POST /api/groups/:userId/:groupName/apply': {
+          description: 'Apply a saved group pattern',
+          parameters: {
+            userId: 'string (required) - User ID',
+            groupName: 'string (required) - Name of the group to apply'
+          },
+          response: 'Grouping result with matched channels'
+        },
+        'GET /api/suggestions': {
+          description: 'Get suggested regex patterns',
+          parameters: 'None',
+          response: 'Array of pattern suggestions'
+        }
+      },
+      examples: {
+        'Group channels starting with "dev"': {
+          method: 'POST',
+          endpoint: '/api/channels/group',
+          body: {
+            pattern: '^dev',
+            flags: 'i'
+          }
+        },
+        'Save a group for engineering channels': {
+          method: 'POST',
+          endpoint: '/api/groups/U123456789',
+          body: {
+            groupName: 'engineering',
+            pattern: '^(dev|eng|api|backend|frontend)',
+            flags: 'i'
+          }
+        }
+      }
+    };
+
+    res.json(docs);
+  }
+
+  getRouter() {
+    return this.router;
+  }
+}
+
+module.exports = APIRoutes;

--- a/src/config/logger.js
+++ b/src/config/logger.js
@@ -1,0 +1,26 @@
+const winston = require('winston');
+
+const logger = winston.createLogger({
+  level: process.env.NODE_ENV === 'production' ? 'info' : 'debug',
+  format: winston.format.combine(
+    winston.format.timestamp(),
+    winston.format.errors({ stack: true }),
+    winston.format.json()
+  ),
+  defaultMeta: { service: 'slack-channel-grouper' },
+  transports: [
+    new winston.transports.File({ filename: 'logs/error.log', level: 'error' }),
+    new winston.transports.File({ filename: 'logs/combined.log' }),
+  ],
+});
+
+if (process.env.NODE_ENV !== 'production') {
+  logger.add(new winston.transports.Console({
+    format: winston.format.combine(
+      winston.format.colorize(),
+      winston.format.simple()
+    )
+  }));
+}
+
+module.exports = logger;

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,242 @@
+const { App } = require('@slack/bolt');
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+require('dotenv').config();
+
+const ChannelGrouperService = require('./services/channelGrouper');
+const SlashCommandHandler = require('./slack/commands');
+const APIRoutes = require('./api/routes');
+const logger = require('./config/logger');
+
+class SlackChannelGrouperBot {
+  constructor() {
+    // Initialize services
+    this.channelGrouper = new ChannelGrouperService(process.env.SLACK_BOT_TOKEN);
+    this.commandHandler = new SlashCommandHandler(this.channelGrouper);
+    
+    // Initialize Slack app
+    this.slackApp = new App({
+      token: process.env.SLACK_BOT_TOKEN,
+      signingSecret: process.env.SLACK_SIGNING_SECRET,
+      socketMode: true,
+      appToken: process.env.SLACK_APP_TOKEN,
+      port: process.env.PORT || 3000,
+    });
+
+    // Initialize Express app for API
+    this.expressApp = express();
+    this.apiRoutes = new APIRoutes(this.channelGrouper);
+    
+    this.setupSlackHandlers();
+    this.setupExpressRoutes();
+    this.ensureLogsDirectory();
+  }
+
+  ensureLogsDirectory() {
+    const logsDir = path.join(process.cwd(), 'logs');
+    if (!fs.existsSync(logsDir)) {
+      fs.mkdirSync(logsDir, { recursive: true });
+    }
+  }
+
+  setupSlackHandlers() {
+    // Handle the main slash command
+    this.slackApp.command('/group-channels', async (args) => {
+      await this.commandHandler.handleGroupChannels(args);
+    });
+
+    // Handle interactive button clicks
+    this.slackApp.action(/^(apply_group_|try_pattern)/, async (args) => {
+      await this.commandHandler.handleInteractiveActions(args);
+    });
+
+    // Handle app home opened (optional - for user onboarding)
+    this.slackApp.event('app_home_opened', async ({ event, client }) => {
+      try {
+        const result = await client.views.publish({
+          user_id: event.user,
+          view: {
+            type: 'home',
+            blocks: [
+              {
+                type: 'section',
+                text: {
+                  type: 'mrkdwn',
+                  text: '*Welcome to Channel Grouper Bot! 🚀*\n\nI help you organize and find Slack channels using powerful regex patterns.'
+                }
+              },
+              {
+                type: 'divider'
+              },
+              {
+                type: 'section',
+                text: {
+                  type: 'mrkdwn',
+                  text: '*Quick Start:*\n• Use `/group-channels search <pattern>` to find channels\n• Use `/group-channels help` for all commands\n• Use `/group-channels suggestions` for pattern ideas'
+                }
+              },
+              {
+                type: 'actions',
+                elements: [
+                  {
+                    type: 'button',
+                    text: {
+                      type: 'plain_text',
+                      text: 'View Help'
+                    },
+                    action_id: 'show_help',
+                    style: 'primary'
+                  },
+                  {
+                    type: 'button',
+                    text: {
+                      type: 'plain_text',
+                      text: 'Get Suggestions'
+                    },
+                    action_id: 'show_suggestions'
+                  }
+                ]
+              }
+            ]
+          }
+        });
+      } catch (error) {
+        logger.error('Error publishing home view:', error);
+      }
+    });
+
+    // Handle home view button clicks
+    this.slackApp.action('show_help', async ({ ack, respond }) => {
+      await ack();
+      await this.commandHandler.handleHelp(respond);
+    });
+
+    this.slackApp.action('show_suggestions', async ({ ack, respond }) => {
+      await ack();
+      await this.commandHandler.handleSuggestions(respond);
+    });
+
+    // Error handling
+    this.slackApp.error((error) => {
+      logger.error('Slack app error:', error);
+    });
+  }
+
+  setupExpressRoutes() {
+    // Health check
+    this.expressApp.get('/health', (req, res) => {
+      res.json({
+        status: 'healthy',
+        timestamp: new Date().toISOString(),
+        services: {
+          slack: 'running',
+          api: 'running'
+        }
+      });
+    });
+
+    // API routes
+    this.expressApp.use('/api', this.apiRoutes.getRouter());
+
+    // Serve documentation
+    this.expressApp.get('/', (req, res) => {
+      res.json({
+        name: 'Slack Channel Grouper Bot',
+        version: '1.0.0',
+        description: 'A bot that groups Slack channels using regex patterns',
+        endpoints: {
+          health: '/health',
+          api: '/api',
+          documentation: '/api/docs'
+        },
+        slack: {
+          command: '/group-channels',
+          description: 'Use this command in Slack to group channels by regex patterns'
+        },
+        mcp: {
+          description: 'Run `npm run mcp` to start the MCP server',
+          tools: [
+            'group_channels_by_regex',
+            'get_all_channels',
+            'save_channel_group',
+            'get_user_groups',
+            'apply_saved_group',
+            'delete_saved_group',
+            'get_pattern_suggestions'
+          ]
+        }
+      });
+    });
+
+    // Error handling for Express
+    this.expressApp.use((error, req, res, next) => {
+      logger.error('Express error:', error);
+      res.status(500).json({
+        success: false,
+        error: 'Internal server error'
+      });
+    });
+  }
+
+  async start() {
+    try {
+      // Start Slack app
+      await this.slackApp.start();
+      logger.info('⚡️ Slack Channel Grouper Bot is running!');
+
+      // Start Express server
+      const port = process.env.PORT || 3000;
+      this.expressApp.listen(port, () => {
+        logger.info(`🌐 API server running on port ${port}`);
+        logger.info(`📖 API documentation available at http://localhost:${port}/api/docs`);
+      });
+
+      // Log startup information
+      logger.info('🤖 Available features:');
+      logger.info('  - Slack slash command: /group-channels');
+      logger.info('  - REST API: /api/*');
+      logger.info('  - MCP server: npm run mcp');
+      
+      return true;
+    } catch (error) {
+      logger.error('Failed to start bot:', error);
+      process.exit(1);
+    }
+  }
+
+  async stop() {
+    try {
+      await this.slackApp.stop();
+      logger.info('🛑 Slack Channel Grouper Bot stopped');
+    } catch (error) {
+      logger.error('Error stopping bot:', error);
+    }
+  }
+}
+
+// Handle graceful shutdown
+process.on('SIGINT', async () => {
+  logger.info('Received SIGINT, shutting down gracefully...');
+  if (global.botInstance) {
+    await global.botInstance.stop();
+  }
+  process.exit(0);
+});
+
+process.on('SIGTERM', async () => {
+  logger.info('Received SIGTERM, shutting down gracefully...');
+  if (global.botInstance) {
+    await global.botInstance.stop();
+  }
+  process.exit(0);
+});
+
+// Start the bot if this file is run directly
+if (require.main === module) {
+  const bot = new SlackChannelGrouperBot();
+  global.botInstance = bot;
+  bot.start();
+}
+
+module.exports = SlackChannelGrouperBot;

--- a/src/mcp-server.js
+++ b/src/mcp-server.js
@@ -1,0 +1,444 @@
+const { Server } = require('@modelcontextprotocol/sdk/server/index.js');
+const { StdioServerTransport } = require('@modelcontextprotocol/sdk/server/stdio.js');
+const {
+  CallToolRequestSchema,
+  ErrorCode,
+  ListToolsRequestSchema,
+  McpError,
+} = require('@modelcontextprotocol/sdk/types.js');
+const ChannelGrouperService = require('./services/channelGrouper');
+const logger = require('./config/logger');
+
+require('dotenv').config();
+
+class MCPChannelGrouperServer {
+  constructor() {
+    this.server = new Server(
+      {
+        name: 'slack-channel-grouper',
+        version: '1.0.0',
+      },
+      {
+        capabilities: {
+          tools: {},
+        },
+      }
+    );
+
+    this.channelGrouper = new ChannelGrouperService(process.env.SLACK_BOT_TOKEN);
+    this.setupHandlers();
+  }
+
+  setupHandlers() {
+    // List available tools
+    this.server.setRequestHandler(ListToolsRequestSchema, async () => {
+      return {
+        tools: [
+          {
+            name: 'group_channels_by_regex',
+            description: 'Group Slack channels using a regex pattern',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                pattern: {
+                  type: 'string',
+                  description: 'Regex pattern to match channel names, topics, or purposes',
+                },
+                flags: {
+                  type: 'string',
+                  description: 'Regex flags (default: "i" for case-insensitive)',
+                  default: 'i',
+                },
+              },
+              required: ['pattern'],
+            },
+          },
+          {
+            name: 'get_all_channels',
+            description: 'Get all channels in the Slack workspace',
+            inputSchema: {
+              type: 'object',
+              properties: {},
+            },
+          },
+          {
+            name: 'save_channel_group',
+            description: 'Save a named channel group with a regex pattern',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                userId: {
+                  type: 'string',
+                  description: 'User ID to associate the group with',
+                },
+                groupName: {
+                  type: 'string',
+                  description: 'Name for the saved group',
+                },
+                pattern: {
+                  type: 'string',
+                  description: 'Regex pattern for the group',
+                },
+                flags: {
+                  type: 'string',
+                  description: 'Regex flags (default: "i")',
+                  default: 'i',
+                },
+              },
+              required: ['userId', 'groupName', 'pattern'],
+            },
+          },
+          {
+            name: 'get_user_groups',
+            description: 'Get all saved groups for a user',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                userId: {
+                  type: 'string',
+                  description: 'User ID to get groups for',
+                },
+              },
+              required: ['userId'],
+            },
+          },
+          {
+            name: 'apply_saved_group',
+            description: 'Apply a saved group pattern to find matching channels',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                userId: {
+                  type: 'string',
+                  description: 'User ID who owns the group',
+                },
+                groupName: {
+                  type: 'string',
+                  description: 'Name of the saved group to apply',
+                },
+              },
+              required: ['userId', 'groupName'],
+            },
+          },
+          {
+            name: 'delete_saved_group',
+            description: 'Delete a saved channel group',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                userId: {
+                  type: 'string',
+                  description: 'User ID who owns the group',
+                },
+                groupName: {
+                  type: 'string',
+                  description: 'Name of the group to delete',
+                },
+              },
+              required: ['userId', 'groupName'],
+            },
+          },
+          {
+            name: 'get_pattern_suggestions',
+            description: 'Get suggested regex patterns for common channel groupings',
+            inputSchema: {
+              type: 'object',
+              properties: {},
+            },
+          },
+        ],
+      };
+    });
+
+    // Handle tool calls
+    this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
+      const { name, arguments: args } = request.params;
+
+      try {
+        switch (name) {
+          case 'group_channels_by_regex':
+            return await this.handleGroupChannelsByRegex(args);
+          
+          case 'get_all_channels':
+            return await this.handleGetAllChannels(args);
+          
+          case 'save_channel_group':
+            return await this.handleSaveChannelGroup(args);
+          
+          case 'get_user_groups':
+            return await this.handleGetUserGroups(args);
+          
+          case 'apply_saved_group':
+            return await this.handleApplySavedGroup(args);
+          
+          case 'delete_saved_group':
+            return await this.handleDeleteSavedGroup(args);
+          
+          case 'get_pattern_suggestions':
+            return await this.handleGetPatternSuggestions(args);
+          
+          default:
+            throw new McpError(
+              ErrorCode.MethodNotFound,
+              `Unknown tool: ${name}`
+            );
+        }
+      } catch (error) {
+        logger.error(`Error handling tool call ${name}:`, error);
+        
+        if (error instanceof McpError) {
+          throw error;
+        }
+        
+        throw new McpError(
+          ErrorCode.InternalError,
+          `Tool execution failed: ${error.message}`
+        );
+      }
+    });
+  }
+
+  async handleGroupChannelsByRegex(args) {
+    const { pattern, flags = 'i' } = args;
+    
+    if (!pattern) {
+      throw new McpError(ErrorCode.InvalidParams, 'Pattern is required');
+    }
+
+    try {
+      const result = await this.channelGrouper.groupChannelsByRegex(pattern, flags);
+      
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              success: true,
+              pattern,
+              flags,
+              totalChannels: result.totalChannels,
+              matchedChannels: result.matchedChannels,
+              channels: result.channels.map(ch => ({
+                id: ch.id,
+                name: ch.name,
+                is_private: ch.is_private,
+                is_archived: ch.is_archived,
+                topic: ch.topic,
+                purpose: ch.purpose
+              }))
+            }, null, 2)
+          }
+        ]
+      };
+    } catch (error) {
+      throw new McpError(ErrorCode.InternalError, error.message);
+    }
+  }
+
+  async handleGetAllChannels(args) {
+    try {
+      const channels = await this.channelGrouper.getAllChannels();
+      
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              success: true,
+              totalChannels: channels.length,
+              channels: channels.map(ch => ({
+                id: ch.id,
+                name: ch.name,
+                is_private: ch.is_private,
+                is_archived: ch.is_archived,
+                topic: ch.topic,
+                purpose: ch.purpose
+              }))
+            }, null, 2)
+          }
+        ]
+      };
+    } catch (error) {
+      throw new McpError(ErrorCode.InternalError, error.message);
+    }
+  }
+
+  async handleSaveChannelGroup(args) {
+    const { userId, groupName, pattern, flags = 'i' } = args;
+    
+    if (!userId || !groupName || !pattern) {
+      throw new McpError(ErrorCode.InvalidParams, 'userId, groupName, and pattern are required');
+    }
+
+    try {
+      // Validate regex pattern
+      new RegExp(pattern, flags);
+      
+      this.channelGrouper.saveGroup(userId, groupName, pattern, flags);
+      
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              success: true,
+              message: `Group "${groupName}" saved successfully for user ${userId}`,
+              groupName,
+              pattern,
+              flags
+            }, null, 2)
+          }
+        ]
+      };
+    } catch (error) {
+      if (error.message.includes('Invalid regular expression')) {
+        throw new McpError(ErrorCode.InvalidParams, `Invalid regex pattern: ${error.message}`);
+      }
+      throw new McpError(ErrorCode.InternalError, error.message);
+    }
+  }
+
+  async handleGetUserGroups(args) {
+    const { userId } = args;
+    
+    if (!userId) {
+      throw new McpError(ErrorCode.InvalidParams, 'userId is required');
+    }
+
+    try {
+      const groups = this.channelGrouper.getUserGroups(userId);
+      
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              success: true,
+              userId,
+              groups: groups.map(group => ({
+                name: group.name,
+                pattern: group.pattern,
+                flags: group.flags,
+                createdAt: group.createdAt
+              }))
+            }, null, 2)
+          }
+        ]
+      };
+    } catch (error) {
+      throw new McpError(ErrorCode.InternalError, error.message);
+    }
+  }
+
+  async handleApplySavedGroup(args) {
+    const { userId, groupName } = args;
+    
+    if (!userId || !groupName) {
+      throw new McpError(ErrorCode.InvalidParams, 'userId and groupName are required');
+    }
+
+    try {
+      const result = await this.channelGrouper.applySavedGroup(userId, groupName);
+      
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              success: true,
+              groupName,
+              pattern: result.pattern,
+              flags: result.flags,
+              totalChannels: result.totalChannels,
+              matchedChannels: result.matchedChannels,
+              channels: result.channels.map(ch => ({
+                id: ch.id,
+                name: ch.name,
+                is_private: ch.is_private,
+                is_archived: ch.is_archived,
+                topic: ch.topic,
+                purpose: ch.purpose
+              }))
+            }, null, 2)
+          }
+        ]
+      };
+    } catch (error) {
+      throw new McpError(ErrorCode.InvalidParams, error.message);
+    }
+  }
+
+  async handleDeleteSavedGroup(args) {
+    const { userId, groupName } = args;
+    
+    if (!userId || !groupName) {
+      throw new McpError(ErrorCode.InvalidParams, 'userId and groupName are required');
+    }
+
+    try {
+      const deleted = this.channelGrouper.deleteGroup(userId, groupName);
+      
+      if (deleted) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                success: true,
+                message: `Group "${groupName}" deleted successfully`
+              }, null, 2)
+            }
+          ]
+        };
+      } else {
+        throw new McpError(ErrorCode.InvalidParams, `Group "${groupName}" not found for user ${userId}`);
+      }
+    } catch (error) {
+      if (error instanceof McpError) {
+        throw error;
+      }
+      throw new McpError(ErrorCode.InternalError, error.message);
+    }
+  }
+
+  async handleGetPatternSuggestions(args) {
+    try {
+      const suggestions = this.channelGrouper.getSuggestions();
+      
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              success: true,
+              suggestions: suggestions.map(suggestion => ({
+                name: suggestion.name,
+                pattern: suggestion.pattern,
+                description: suggestion.description
+              }))
+            }, null, 2)
+          }
+        ]
+      };
+    } catch (error) {
+      throw new McpError(ErrorCode.InternalError, error.message);
+    }
+  }
+
+  async run() {
+    const transport = new StdioServerTransport();
+    await this.server.connect(transport);
+    logger.info('MCP Slack Channel Grouper Server started');
+  }
+}
+
+// Start the server
+if (require.main === module) {
+  const server = new MCPChannelGrouperServer();
+  server.run().catch((error) => {
+    logger.error('Failed to start MCP server:', error);
+    process.exit(1);
+  });
+}
+
+module.exports = MCPChannelGrouperServer;

--- a/src/services/channelGrouper.js
+++ b/src/services/channelGrouper.js
@@ -1,0 +1,229 @@
+const { WebClient } = require('@slack/web-api');
+const logger = require('../config/logger');
+
+class ChannelGrouperService {
+  constructor(token) {
+    this.slack = new WebClient(token);
+    this.groups = new Map(); // Store user-defined groups
+  }
+
+  /**
+   * Get all channels in the workspace
+   */
+  async getAllChannels() {
+    try {
+      const result = await this.slack.conversations.list({
+        types: 'public_channel,private_channel',
+        limit: 1000
+      });
+      
+      return result.channels.map(channel => ({
+        id: channel.id,
+        name: channel.name,
+        is_private: channel.is_private,
+        is_archived: channel.is_archived,
+        topic: channel.topic?.value || '',
+        purpose: channel.purpose?.value || ''
+      }));
+    } catch (error) {
+      logger.error('Error fetching channels:', error);
+      throw new Error('Failed to fetch channels');
+    }
+  }
+
+  /**
+   * Group channels by regex pattern
+   */
+  async groupChannelsByRegex(pattern, flags = 'i') {
+    try {
+      const regex = new RegExp(pattern, flags);
+      const channels = await this.getAllChannels();
+      
+      const matchedChannels = channels.filter(channel => {
+        return regex.test(channel.name) || 
+               regex.test(channel.topic) || 
+               regex.test(channel.purpose);
+      });
+
+      return {
+        pattern,
+        flags,
+        totalChannels: channels.length,
+        matchedChannels: matchedChannels.length,
+        channels: matchedChannels
+      };
+    } catch (error) {
+      logger.error('Error grouping channels:', error);
+      if (error.message.includes('Invalid regular expression')) {
+        throw new Error('Invalid regex pattern provided');
+      }
+      throw new Error('Failed to group channels');
+    }
+  }
+
+  /**
+   * Save a named group
+   */
+  saveGroup(userId, groupName, pattern, flags = 'i') {
+    const userGroups = this.groups.get(userId) || new Map();
+    userGroups.set(groupName, { pattern, flags, createdAt: new Date() });
+    this.groups.set(userId, userGroups);
+    
+    logger.info(`Group '${groupName}' saved for user ${userId}`);
+    return true;
+  }
+
+  /**
+   * Get saved groups for a user
+   */
+  getUserGroups(userId) {
+    const userGroups = this.groups.get(userId) || new Map();
+    return Array.from(userGroups.entries()).map(([name, config]) => ({
+      name,
+      pattern: config.pattern,
+      flags: config.flags,
+      createdAt: config.createdAt
+    }));
+  }
+
+  /**
+   * Delete a saved group
+   */
+  deleteGroup(userId, groupName) {
+    const userGroups = this.groups.get(userId);
+    if (!userGroups || !userGroups.has(groupName)) {
+      return false;
+    }
+    
+    userGroups.delete(groupName);
+    if (userGroups.size === 0) {
+      this.groups.delete(userId);
+    }
+    
+    logger.info(`Group '${groupName}' deleted for user ${userId}`);
+    return true;
+  }
+
+  /**
+   * Apply a saved group
+   */
+  async applySavedGroup(userId, groupName) {
+    const userGroups = this.groups.get(userId);
+    if (!userGroups || !userGroups.has(groupName)) {
+      throw new Error(`Group '${groupName}' not found`);
+    }
+    
+    const config = userGroups.get(groupName);
+    return await this.groupChannelsByRegex(config.pattern, config.flags);
+  }
+
+  /**
+   * Get group suggestions based on common patterns
+   */
+  getSuggestions() {
+    return [
+      {
+        name: 'Engineering Channels',
+        pattern: '^(dev|eng|engineering|tech|api|backend|frontend)',
+        description: 'Channels starting with development-related keywords'
+      },
+      {
+        name: 'Project Channels',
+        pattern: 'project-|proj-',
+        description: 'Channels containing project prefixes'
+      },
+      {
+        name: 'Team Channels',
+        pattern: 'team-|^(sales|marketing|hr|design|product)',
+        description: 'Team-specific channels'
+      },
+      {
+        name: 'Temporary Channels',
+        pattern: '(temp|tmp|test|sandbox)',
+        description: 'Temporary or testing channels'
+      },
+      {
+        name: 'Date-based Channels',
+        pattern: '\\d{4}|202[0-9]|q[1-4]',
+        description: 'Channels with years or quarters'
+      }
+    ];
+  }
+
+  /**
+   * Format channels for Slack display
+   */
+  formatChannelsForSlack(groupResult, limit = 20) {
+    const { pattern, matchedChannels, channels } = groupResult;
+    
+    if (matchedChannels === 0) {
+      return {
+        text: `No channels found matching pattern: \`${pattern}\``,
+        blocks: []
+      };
+    }
+
+    const displayChannels = channels.slice(0, limit);
+    const hasMore = channels.length > limit;
+
+    const blocks = [
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `*Found ${matchedChannels} channels matching pattern:* \`${pattern}\``
+        }
+      },
+      {
+        type: 'divider'
+      }
+    ];
+
+    // Group channels by type
+    const publicChannels = displayChannels.filter(ch => !ch.is_private);
+    const privateChannels = displayChannels.filter(ch => ch.is_private);
+
+    if (publicChannels.length > 0) {
+      blocks.push({
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `*Public Channels (${publicChannels.length}):*\n${publicChannels.map(ch => 
+            `• <#${ch.id}|${ch.name}>${ch.is_archived ? ' (archived)' : ''}`
+          ).join('\n')}`
+        }
+      });
+    }
+
+    if (privateChannels.length > 0) {
+      blocks.push({
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `*Private Channels (${privateChannels.length}):*\n${privateChannels.map(ch => 
+            `• #${ch.name}${ch.is_archived ? ' (archived)' : ''}`
+          ).join('\n')}`
+        }
+      });
+    }
+
+    if (hasMore) {
+      blocks.push({
+        type: 'context',
+        elements: [
+          {
+            type: 'mrkdwn',
+            text: `_Showing first ${limit} channels. ${channels.length - limit} more channels match this pattern._`
+          }
+        ]
+      });
+    }
+
+    return {
+      text: `Found ${matchedChannels} channels matching pattern: ${pattern}`,
+      blocks
+    };
+  }
+}
+
+module.exports = ChannelGrouperService;

--- a/src/slack/commands.js
+++ b/src/slack/commands.js
@@ -1,0 +1,364 @@
+const logger = require('../config/logger');
+
+class SlashCommandHandler {
+  constructor(channelGrouper) {
+    this.channelGrouper = channelGrouper;
+  }
+
+  /**
+   * Parse command arguments
+   */
+  parseCommand(text) {
+    const args = text.trim().split(/\s+/);
+    const command = args[0] || 'help';
+    const params = args.slice(1);
+    
+    return { command, params, rawText: text };
+  }
+
+  /**
+   * Main slash command handler
+   */
+  async handleGroupChannels({ command, ack, respond, body }) {
+    await ack();
+    
+    try {
+      const { command: cmd, params } = this.parseCommand(command.text);
+      const userId = body.user_id;
+      
+      logger.info(`User ${userId} executed command: ${cmd} with params: ${params.join(' ')}`);
+
+      switch (cmd) {
+        case 'search':
+        case 'group':
+          await this.handleSearch(respond, params);
+          break;
+        
+        case 'save':
+          await this.handleSave(respond, userId, params);
+          break;
+        
+        case 'list':
+          await this.handleList(respond, userId);
+          break;
+        
+        case 'delete':
+        case 'remove':
+          await this.handleDelete(respond, userId, params);
+          break;
+        
+        case 'apply':
+        case 'use':
+          await this.handleApply(respond, userId, params);
+          break;
+        
+        case 'suggestions':
+        case 'suggest':
+          await this.handleSuggestions(respond);
+          break;
+        
+        case 'help':
+        default:
+          await this.handleHelp(respond);
+          break;
+      }
+    } catch (error) {
+      logger.error('Error handling slash command:', error);
+      await respond({
+        text: `❌ Error: ${error.message}`,
+        response_type: 'ephemeral'
+      });
+    }
+  }
+
+  /**
+   * Handle search/group command
+   */
+  async handleSearch(respond, params) {
+    if (params.length === 0) {
+      await respond({
+        text: '❌ Please provide a regex pattern. Example: `/group-channels search ^dev`',
+        response_type: 'ephemeral'
+      });
+      return;
+    }
+
+    const pattern = params.join(' ');
+    const result = await this.channelGrouper.groupChannelsByRegex(pattern);
+    const formatted = this.channelGrouper.formatChannelsForSlack(result);
+
+    await respond({
+      ...formatted,
+      response_type: 'in_channel'
+    });
+  }
+
+  /**
+   * Handle save command
+   */
+  async handleSave(respond, userId, params) {
+    if (params.length < 2) {
+      await respond({
+        text: '❌ Please provide a group name and regex pattern. Example: `/group-channels save "dev-channels" ^dev`',
+        response_type: 'ephemeral'
+      });
+      return;
+    }
+
+    const groupName = params[0].replace(/"/g, '');
+    const pattern = params.slice(1).join(' ');
+
+    // Test the regex pattern first
+    try {
+      new RegExp(pattern);
+    } catch (error) {
+      await respond({
+        text: `❌ Invalid regex pattern: ${error.message}`,
+        response_type: 'ephemeral'
+      });
+      return;
+    }
+
+    this.channelGrouper.saveGroup(userId, groupName, pattern);
+
+    await respond({
+      text: `✅ Group "${groupName}" saved with pattern: \`${pattern}\``,
+      response_type: 'ephemeral'
+    });
+  }
+
+  /**
+   * Handle list command
+   */
+  async handleList(respond, userId) {
+    const groups = this.channelGrouper.getUserGroups(userId);
+
+    if (groups.length === 0) {
+      await respond({
+        text: '📝 You have no saved channel groups. Use `/group-channels save` to create one.',
+        response_type: 'ephemeral'
+      });
+      return;
+    }
+
+    const blocks = [
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: '*Your Saved Channel Groups:*'
+        }
+      },
+      {
+        type: 'divider'
+      }
+    ];
+
+    groups.forEach(group => {
+      blocks.push({
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `*${group.name}*\nPattern: \`${group.pattern}\`\nCreated: ${group.createdAt.toLocaleDateString()}`
+        },
+        accessory: {
+          type: 'button',
+          text: {
+            type: 'plain_text',
+            text: 'Apply'
+          },
+          action_id: `apply_group_${group.name}`,
+          value: group.name
+        }
+      });
+    });
+
+    await respond({
+      text: 'Your saved channel groups',
+      blocks,
+      response_type: 'ephemeral'
+    });
+  }
+
+  /**
+   * Handle delete command
+   */
+  async handleDelete(respond, userId, params) {
+    if (params.length === 0) {
+      await respond({
+        text: '❌ Please provide a group name to delete. Example: `/group-channels delete "dev-channels"`',
+        response_type: 'ephemeral'
+      });
+      return;
+    }
+
+    const groupName = params.join(' ').replace(/"/g, '');
+    const deleted = this.channelGrouper.deleteGroup(userId, groupName);
+
+    if (deleted) {
+      await respond({
+        text: `✅ Group "${groupName}" has been deleted.`,
+        response_type: 'ephemeral'
+      });
+    } else {
+      await respond({
+        text: `❌ Group "${groupName}" not found.`,
+        response_type: 'ephemeral'
+      });
+    }
+  }
+
+  /**
+   * Handle apply command
+   */
+  async handleApply(respond, userId, params) {
+    if (params.length === 0) {
+      await respond({
+        text: '❌ Please provide a group name to apply. Example: `/group-channels apply "dev-channels"`',
+        response_type: 'ephemeral'
+      });
+      return;
+    }
+
+    const groupName = params.join(' ').replace(/"/g, '');
+    
+    try {
+      const result = await this.channelGrouper.applySavedGroup(userId, groupName);
+      const formatted = this.channelGrouper.formatChannelsForSlack(result);
+
+      await respond({
+        ...formatted,
+        response_type: 'in_channel'
+      });
+    } catch (error) {
+      await respond({
+        text: `❌ ${error.message}`,
+        response_type: 'ephemeral'
+      });
+    }
+  }
+
+  /**
+   * Handle suggestions command
+   */
+  async handleSuggestions(respond) {
+    const suggestions = this.channelGrouper.getSuggestions();
+
+    const blocks = [
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: '*🔍 Suggested Channel Grouping Patterns:*'
+        }
+      },
+      {
+        type: 'divider'
+      }
+    ];
+
+    suggestions.forEach(suggestion => {
+      blocks.push({
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `*${suggestion.name}*\n\`${suggestion.pattern}\`\n_${suggestion.description}_`
+        },
+        accessory: {
+          type: 'button',
+          text: {
+            type: 'plain_text',
+            text: 'Try Pattern'
+          },
+          action_id: `try_pattern`,
+          value: suggestion.pattern
+        }
+      });
+    });
+
+    await respond({
+      text: 'Channel grouping suggestions',
+      blocks,
+      response_type: 'ephemeral'
+    });
+  }
+
+  /**
+   * Handle help command
+   */
+  async handleHelp(respond) {
+    const helpText = `
+*🤖 Channel Grouper Bot Help*
+
+*Basic Commands:*
+• \`/group-channels search <regex>\` - Find channels matching a regex pattern
+• \`/group-channels suggestions\` - View common grouping patterns
+
+*Saved Groups:*
+• \`/group-channels save "<name>" <regex>\` - Save a regex pattern with a name
+• \`/group-channels list\` - View your saved groups
+• \`/group-channels apply "<name>"\` - Apply a saved group
+• \`/group-channels delete "<name>"\` - Delete a saved group
+
+*Examples:*
+• \`/group-channels search ^dev\` - Find channels starting with "dev"
+• \`/group-channels search team-\` - Find channels containing "team-"
+• \`/group-channels save "dev-channels" ^(dev|eng|api)\` - Save a pattern for development channels
+• \`/group-channels apply "dev-channels"\` - Use your saved "dev-channels" pattern
+
+*Regex Tips:*
+• \`^\` - Start of channel name
+• \`$\` - End of channel name
+• \`|\` - OR operator
+• \`()\` - Grouping
+• \`[]\` - Character sets
+    `;
+
+    await respond({
+      text: helpText,
+      response_type: 'ephemeral'
+    });
+  }
+
+  /**
+   * Handle interactive button clicks
+   */
+  async handleInteractiveActions({ action, ack, respond, body }) {
+    await ack();
+
+    try {
+      const actionId = action.action_id;
+      const userId = body.user.id;
+
+      if (actionId.startsWith('apply_group_')) {
+        const groupName = action.value;
+        const result = await this.channelGrouper.applySavedGroup(userId, groupName);
+        const formatted = this.channelGrouper.formatChannelsForSlack(result);
+
+        await respond({
+          ...formatted,
+          response_type: 'in_channel',
+          replace_original: false
+        });
+      } else if (actionId === 'try_pattern') {
+        const pattern = action.value;
+        const result = await this.channelGrouper.groupChannelsByRegex(pattern);
+        const formatted = this.channelGrouper.formatChannelsForSlack(result);
+
+        await respond({
+          ...formatted,
+          response_type: 'in_channel',
+          replace_original: false
+        });
+      }
+    } catch (error) {
+      logger.error('Error handling interactive action:', error);
+      await respond({
+        text: `❌ Error: ${error.message}`,
+        response_type: 'ephemeral'
+      });
+    }
+  }
+}
+
+module.exports = SlashCommandHandler;

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,39 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "api/**/*.js",
+      "use": "@vercel/node"
+    }
+  ],
+  "routes": [
+    {
+      "src": "/api/(.*)",
+      "dest": "/api/$1"
+    },
+    {
+      "src": "/slack/events",
+      "dest": "/api/slack/events"
+    },
+    {
+      "src": "/slack/interactive",
+      "dest": "/api/slack/interactive"
+    },
+    {
+      "src": "/slack/commands",
+      "dest": "/api/slack/commands"
+    },
+    {
+      "src": "/(.*)",
+      "dest": "/api/index"
+    }
+  ],
+  "env": {
+    "NODE_ENV": "production"
+  },
+  "functions": {
+    "api/**/*.js": {
+      "maxDuration": 30
+    }
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,11 +1,5 @@
 {
   "version": 2,
-  "builds": [
-    {
-      "src": "api/**/*.js",
-      "use": "@vercel/node"
-    }
-  ],
   "routes": [
     {
       "src": "/api/(.*)",
@@ -28,9 +22,6 @@
       "dest": "/api/index"
     }
   ],
-  "env": {
-    "NODE_ENV": "production"
-  },
   "functions": {
     "api/**/*.js": {
       "maxDuration": 30


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Enable Vercel serverless deployment for the Slack Channel Grouper Bot.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This refactors the bot from a long-running, stateful server to a stateless serverless architecture, making it compatible with Vercel's environment. Consequently, persistent saved channel groups are no longer supported in this deployment model, and the MCP server is now a separate deployment option.